### PR TITLE
fix: Fix table overlap issue when creating multiple tables

### DIFF
--- a/src/components/DiagramEditor.tsx
+++ b/src/components/DiagramEditor.tsx
@@ -7,7 +7,7 @@ import {
 import { tableColors } from "@/lib/colors";
 import { colors, DbRelationship, relationshipTypes } from "@/lib/constants";
 import { type AppEdge, type AppNode, type AppNoteNode, type AppZoneNode, type ProcessedEdge, type ProcessedNode } from "@/lib/types";
-import { isNodeInLockedZone } from "@/lib/utils";
+import { findNonOverlappingPosition, isNodeInLockedZone } from "@/lib/utils";
 import { useStore, type StoreState } from "@/store/store";
 import { showError } from "@/utils/toast";
 import {
@@ -233,10 +233,13 @@ const DiagramEditor = forwardRef(
       if (!diagram) return;
       const visibleNodes = diagram.data.nodes.filter((n: AppNode) => !n.data.isDeleted) || [];
       const tableName = `new_table_${visibleNodes.length + 1}`;
+      const defaultPosition = { x: position.x - 144, y: position.y - 50 };
+      const nonOverlappingPosition = findNonOverlappingPosition(visibleNodes, defaultPosition);
+      
       const newNode: AppNode = {
         id: `${tableName}-${+new Date()}`,
         type: "table",
-        position: { x: position.x - 144, y: position.y - 50 },
+        position: nonOverlappingPosition,
         data: {
           label: tableName,
           color: tableColors[Math.floor(Math.random() * tableColors.length)] ?? colors.DEFAULT_TABLE_COLOR,

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -3,6 +3,7 @@ import { useSidebarState } from "@/hooks/use-sidebar-state";
 import { tableColors } from "@/lib/colors";
 import { colors, KeyboardShortcuts } from "@/lib/constants";
 import { type AppNode, type AppNoteNode, type AppZoneNode, type ProcessedEdge, type ProcessedNode } from "@/lib/types";
+import { findNonOverlappingPosition } from "@/lib/utils";
 import { useStore, type StoreState } from "@/store/store";
 import { showSuccess } from "@/utils/toast";
 import { type ReactFlowInstance } from "@xyflow/react";
@@ -149,16 +150,19 @@ export default function Layout({ onInstallAppRequest }: LayoutProps) {
 
   const handleCreateTable = (tableName: string) => {
     if (!diagram) return;
-    let position = { x: 200, y: 200 };
+    let defaultPosition = { x: 200, y: 200 };
     if (rfInstance) {
       const flowPosition = rfInstance.screenToFlowPosition({ x: window.innerWidth * 0.6, y: window.innerHeight / 2 });
-      position = { x: flowPosition.x - 144, y: flowPosition.y - 50 };
+      defaultPosition = { x: flowPosition.x - 144, y: flowPosition.y - 50 };
     }
+    
     const visibleNodes = diagram.data.nodes.filter((n: AppNode) => !n.data.isDeleted) || [];
+    const nonOverlappingPosition = findNonOverlappingPosition(visibleNodes, defaultPosition);
+    
     const newNode: AppNode = {
       id: `${tableName}-${+new Date()}`,
       type: "table",
-      position,
+      position: nonOverlappingPosition,
       data: {
         label: tableName,
         color: tableColors[Math.floor(Math.random() * tableColors.length)] ?? colors.DEFAULT_TABLE_COLOR,


### PR DESCRIPTION
## Description
When creating multiple tables in the diagram editor, new tables would overlap with existing ones because they were all positioned at the same fixed coordinates relative to the viewport center.
<img width="1396" height="793" alt="image" src="https://github.com/user-attachments/assets/cd5e18c5-3f55-4403-9298-8d53d39ff009" />

Brief summary of changes and motivation.
Implemented a smart positioning algorithm that automatically finds non-overlapping positions for new tables:
- Added utility function `findNonOverlappingPosition` that checks if the default position overlaps with existing nodes and uses a spiral positioning algorithm to find alternative non-overlapping positions. Falls back to placing tables far from existing nodes if needed.
<img width="1396" height="934" alt="image" src="https://github.com/user-attachments/assets/59f0b56b-ffd0-44f6-9736-6644675fd68d" />

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [] Tests added/updated
- [ ] All tests pass locally
- [ ] Tested on multiple browsers (Chrome, Firefox, Safari, Edge)

**Test Environment:**
- Browser:
- OS:

## Checklist

- [ ] Code follows project style
- [ ] Self-reviewed code
- [ ] Updated documentation
- [ ] Backward compatible (or breaking change documented)
- [ ] No new warnings/errors

## Additional Notes

Any extra context or screenshots.