### PR TITLE
feat: add schema assistant ai chatbot 

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@google/genai": "^1.48.0",
     "@hookform/resolvers": "^3.9.0",
     "@radix-ui/react-accordion": "^1.2.0",
     "@radix-ui/react-alert-dialog": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@dnd-kit/utilities':
         specifier: ^3.2.2
         version: 3.2.2(react@18.3.1)
+      '@google/genai':
+        specifier: ^1.48.0
+        version: 1.48.0
       '@hookform/resolvers':
         specifier: ^3.9.0
         version: 3.10.0(react-hook-form@7.55.0(react@18.3.1))
@@ -1080,6 +1083,15 @@ packages:
   '@floating-ui/utils@0.2.9':
     resolution: {integrity: sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==}
 
+  '@google/genai@1.48.0':
+    resolution: {integrity: sha512-plonYK4ML2PrxsRD9SeqmFt76eREWkQdPCglOA6aYDzL1AAbE+7PUnT54SvpWGfws13L0AZEqGSpL7+1IPnTxQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.25.2
+    peerDependenciesMeta:
+      '@modelcontextprotocol/sdk':
+        optional: true
+
   '@hookform/resolvers@3.10.0':
     resolution: {integrity: sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag==}
     peerDependencies:
@@ -1166,6 +1178,36 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.4':
+    resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
+
+  '@protobufjs/eventemitter@1.1.0':
+    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+
+  '@protobufjs/fetch@1.1.0':
+    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.0':
+    resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.0':
+    resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -2119,6 +2161,9 @@ packages:
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
 
+  '@types/retry@0.12.0':
+    resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
+
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
@@ -2255,6 +2300,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
@@ -2353,6 +2402,12 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
@@ -2376,6 +2431,9 @@ packages:
     resolution: {integrity: sha512-4jYpcjabC606xJ3kw2QwGEZKX0Aw7sgQdZCvIK9dhVSPh76BKo+C+btT1RRofH7B+8iNpEbgGNVWiLki5q93yg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -2566,6 +2624,10 @@ packages:
     resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
     engines: {node: '>=12'}
 
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
     engines: {node: '>= 0.4'}
@@ -2655,6 +2717,9 @@ packages:
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   ejs@3.1.10:
     resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
@@ -2826,6 +2891,10 @@ packages:
       picomatch:
         optional: true
 
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
@@ -2863,6 +2932,10 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
 
@@ -2887,6 +2960,14 @@ packages:
 
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+
+  gaxios@7.1.4:
+    resolution: {integrity: sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==}
+    engines: {node: '>=18'}
+
+  gcp-metadata@8.1.2:
+    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
+    engines: {node: '>=18'}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -2939,6 +3020,14 @@ packages:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
 
+  google-auth-library@10.6.2:
+    resolution: {integrity: sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==}
+    engines: {node: '>=18'}
+
+  google-logging-utils@1.1.3:
+    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
+    engines: {node: '>=14'}
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -2987,6 +3076,10 @@ packages:
 
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
@@ -3212,6 +3305,9 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
@@ -3241,6 +3337,12 @@ packages:
 
   jszip@3.10.1:
     resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -3287,6 +3389,9 @@ packages:
 
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
@@ -3491,6 +3596,15 @@ packages:
       react: ^16.8 || ^17 || ^18
       react-dom: ^16.8 || ^17 || ^18
 
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
 
@@ -3540,6 +3654,10 @@ packages:
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
+
+  p-retry@4.6.2:
+    resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
+    engines: {node: '>=8'}
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
@@ -3668,6 +3786,10 @@ packages:
 
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
+  protobufjs@7.5.4:
+    resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
+    engines: {node: '>=12.0.0'}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -3863,6 +3985,10 @@ packages:
     resolution: {integrity: sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==}
     engines: {node: '>= 0.4'}
     hasBin: true
+
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
 
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
@@ -4332,6 +4458,10 @@ packages:
   w3c-keyname@2.2.8:
     resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
+
   webidl-conversions@4.0.2:
     resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
 
@@ -4422,6 +4552,18 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -5396,6 +5538,17 @@ snapshots:
 
   '@floating-ui/utils@0.2.9': {}
 
+  '@google/genai@1.48.0':
+    dependencies:
+      google-auth-library: 10.6.2
+      p-retry: 4.6.2
+      protobufjs: 7.5.4
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   '@hookform/resolvers@3.10.0(react-hook-form@7.55.0(react@18.3.1))':
     dependencies:
       react-hook-form: 7.55.0(react@18.3.1)
@@ -5485,6 +5638,29 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.4': {}
+
+  '@protobufjs/eventemitter@1.1.0': {}
+
+  '@protobufjs/fetch@1.1.0':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/inquire': 1.1.0
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.0': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.0': {}
 
   '@radix-ui/number@1.1.1': {}
 
@@ -6411,6 +6587,8 @@ snapshots:
 
   '@types/resolve@1.20.2': {}
 
+  '@types/retry@0.12.0': {}
+
   '@types/trusted-types@2.0.7': {}
 
   '@types/unist@2.0.11': {}
@@ -6565,6 +6743,8 @@ snapshots:
 
   acorn@8.15.0: {}
 
+  agent-base@7.1.4: {}
+
   ajv@6.12.6:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -6671,6 +6851,10 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  base64-js@1.5.1: {}
+
+  bignumber.js@9.3.1: {}
+
   binary-extensions@2.3.0: {}
 
   brace-expansion@1.1.11:
@@ -6699,6 +6883,8 @@ snapshots:
       electron-to-chromium: 1.5.215
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3(browserslist@4.25.4)
+
+  buffer-equal-constant-time@1.0.1: {}
 
   buffer-from@1.1.2: {}
 
@@ -6886,6 +7072,8 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
+  data-uri-to-buffer@4.0.1: {}
+
   data-view-buffer@1.0.2:
     dependencies:
       call-bound: 1.0.4
@@ -6968,6 +7156,10 @@ snapshots:
       gopd: 1.2.0
 
   eastasianwidth@0.2.0: {}
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.1.2
 
   ejs@3.1.10:
     dependencies:
@@ -7218,6 +7410,11 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.2
 
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
+
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
@@ -7257,6 +7454,10 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
+
   fraction.js@4.3.7: {}
 
   fs-extra@9.1.0:
@@ -7283,6 +7484,22 @@ snapshots:
       is-callable: 1.2.7
 
   functions-have-names@1.2.3: {}
+
+  gaxios@7.1.4:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@8.1.2:
+    dependencies:
+      gaxios: 7.1.4
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   gensync@1.0.0-beta.2: {}
 
@@ -7349,6 +7566,19 @@ snapshots:
       define-properties: 1.2.1
       gopd: 1.2.0
 
+  google-auth-library@10.6.2:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.1.4
+      gcp-metadata: 8.1.2
+      google-logging-utils: 1.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  google-logging-utils@1.1.3: {}
+
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
@@ -7404,6 +7634,13 @@ snapshots:
   html-to-image@1.11.13: {}
 
   html-url-attributes@3.0.1: {}
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.1
+    transitivePeerDependencies:
+      - supports-color
 
   husky@9.1.7: {}
 
@@ -7606,6 +7843,10 @@ snapshots:
 
   jsesc@3.1.0: {}
 
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
+
   json-buffer@3.0.1: {}
 
   json-schema-traverse@0.4.1: {}
@@ -7632,6 +7873,17 @@ snapshots:
       pako: 1.0.11
       readable-stream: 2.3.8
       setimmediate: 1.0.5
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.1.2
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.1.2
 
   keyv@4.5.4:
     dependencies:
@@ -7669,6 +7921,8 @@ snapshots:
   lodash.sortby@4.7.0: {}
 
   lodash@4.17.21: {}
+
+  long@5.3.2: {}
 
   longest-streak@3.1.0: {}
 
@@ -8080,6 +8334,14 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  node-domexception@1.0.0: {}
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
+
   node-releases@2.0.19: {}
 
   normalize-path@3.0.0: {}
@@ -8129,6 +8391,11 @@ snapshots:
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
+
+  p-retry@4.6.2:
+    dependencies:
+      '@types/retry': 0.12.0
+      retry: 0.13.1
 
   package-json-from-dist@1.0.1: {}
 
@@ -8234,6 +8501,21 @@ snapshots:
       react-is: 16.13.1
 
   property-information@7.1.0: {}
+
+  protobufjs@7.5.4:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.4
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.0
+      '@types/node': 22.14.1
+      long: 5.3.2
 
   punycode@2.3.1: {}
 
@@ -8483,6 +8765,8 @@ snapshots:
       is-core-module: 2.16.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+
+  retry@0.13.1: {}
 
   reusify@1.1.0: {}
 
@@ -9049,6 +9333,8 @@ snapshots:
 
   w3c-keyname@2.2.8: {}
 
+  web-streams-polyfill@3.3.3: {}
+
   webidl-conversions@4.0.2: {}
 
   whatwg-url@7.1.0:
@@ -9230,6 +9516,8 @@ snapshots:
       strip-ansi: 7.1.0
 
   wrappy@1.0.2: {}
+
+  ws@8.20.0: {}
 
   yallist@3.1.1: {}
 

--- a/src/components/AiChatFloating.tsx
+++ b/src/components/AiChatFloating.tsx
@@ -1,0 +1,84 @@
+import { cn } from "@/lib/utils";
+import { useStore } from "@/store/store";
+import { Sparkles } from "lucide-react";
+import { useEffect, useMemo } from "react";
+import { useShallow } from "zustand/react/shallow";
+import AiChatTab from "./AiChatTab";
+import { Button } from "./ui/button";
+
+export function AiChatFloating() {
+  const { selectedDiagramId, diagramsMap, aiChatPanelOpen, setAiChatPanelOpen } =
+    useStore(
+      useShallow((s) => ({
+        selectedDiagramId: s.selectedDiagramId,
+        diagramsMap: s.diagramsMap,
+        aiChatPanelOpen: s.aiChatPanelOpen,
+        setAiChatPanelOpen: s.setAiChatPanelOpen,
+      })),
+    );
+
+  const isLocked = useMemo(() => {
+    if (!selectedDiagramId) return false;
+    return diagramsMap.get(selectedDiagramId)?.data.isLocked ?? false;
+  }, [diagramsMap, selectedDiagramId]);
+
+  useEffect(() => {
+    if (!aiChatPanelOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      if (document.querySelector('[data-state="open"][role="dialog"]')) return;
+      setAiChatPanelOpen(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [aiChatPanelOpen, setAiChatPanelOpen]);
+
+  if (!selectedDiagramId) return null;
+
+  return (
+    <div className="pointer-events-none absolute inset-0 z-[35] overflow-visible">
+      {aiChatPanelOpen ? (
+        <button
+          type="button"
+          className="pointer-events-auto absolute inset-0 z-0 bg-background/40 lg:hidden"
+          aria-label="Dismiss assistant"
+          onClick={() => setAiChatPanelOpen(false)}
+        />
+      ) : null}
+
+      <div className="pointer-events-none absolute bottom-6 right-6 z-[1] flex flex-col items-end gap-3">
+        {aiChatPanelOpen ? (
+          <div
+            className={cn(
+              "pointer-events-auto flex h-[min(92dvh,760px)] w-[min(calc(100vw-2rem),28rem)] min-h-0 flex-col overflow-hidden rounded-2xl border bg-card shadow-2xl ring-1 ring-border/50 backdrop-blur-sm",
+            )}
+          >
+            <AiChatTab
+              isLocked={isLocked}
+              variant="floating"
+              onRequestClose={() => setAiChatPanelOpen(false)}
+            />
+          </div>
+        ) : null}
+
+        <Button
+          type="button"
+          size="icon"
+          variant={aiChatPanelOpen ? "secondary" : "default"}
+          className={cn(
+            "pointer-events-auto h-12 w-12 rounded-full shadow-lg",
+            !aiChatPanelOpen && "ring-2 ring-background/80",
+          )}
+          onClick={() => setAiChatPanelOpen(!aiChatPanelOpen)}
+          aria-expanded={aiChatPanelOpen}
+          aria-label={
+            aiChatPanelOpen ? "Close schema assistant" : "Open schema assistant"
+          }
+          data-tour="editor-ai-chat"
+        >
+          <Sparkles className="h-5 w-5" aria-hidden />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/AiChatTab.tsx
+++ b/src/components/AiChatTab.tsx
@@ -1,0 +1,723 @@
+import {
+  loadAiChatHistory,
+  saveAiChatHistory,
+} from "@/lib/ai/aiChatHistory";
+import {
+  buildDiagramContext,
+  diagramContextToPromptJson,
+} from "@/lib/ai/buildDiagramContext";
+import {
+  callGeminiDiagramAssistant,
+  GEMINI_DIAGRAM_MODEL,
+} from "@/lib/ai/callGemini";
+import {
+  hasEncryptedGeminiKey,
+  loadGeminiKeyFromSession,
+} from "@/lib/ai/geminiEncryptedStorage";
+import type { AiChatMessage } from "@/lib/types";
+import { useStore } from "@/store/store";
+import { showError, showSuccess } from "@/utils/toast";
+import { cn } from "@/lib/utils";
+import {
+  Bot,
+  Loader2,
+  Lock,
+  SendHorizontal,
+  Settings2,
+  Sparkles,
+  User,
+  X,
+} from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import Markdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { useShallow } from "zustand/react/shallow";
+import { GeminiKeyModal } from "./GeminiKeyModal";
+import { Badge } from "./ui/badge";
+import { Button } from "./ui/button";
+import { ScrollArea } from "./ui/scroll-area";
+import { Textarea } from "./ui/textarea";
+
+const SYSTEM_INSTRUCTION = `You are the in-app schema copilot for **ThothBlueprint**: a visual ER diagram editor (tables, columns, relationships). Behave like a senior DB designer: clear naming, sensible keys, normalization when it helps, and pragmatic tradeoffs users can maintain.
+
+## Mental model
+- You emit a JSON **patch**, not raw DDL. The app validates and applies updates **atomically** (every operation succeeds or none are applied).
+- Relationships connect **two columns**; their **type** strings must match as stored after normalization.
+- **Out of scope for this API** (mention in **summary** only): SQL indexes, check constraints, triggers, views, notes/zones on the canvas, data migration scripts. Users can add indexes in the table UI or export SQL elsewhere.
+
+## Reading: Current diagram (JSON)
+Each user message ends with a JSON snapshot—parse it every time.
+
+| Field | How to use it |
+|-------|----------------|
+| **dbType** | "mysql" or "postgres" — every column **type** must be valid for that engine. SQL-style types OK: VARCHAR(255), DECIMAL(10,2), INT UNSIGNED. |
+| **editorFocus** | Plain-language hint for selection; use to disambiguate ("add a column" → selected table). |
+| **aiChatTarget** | When non-null, the user pinned one or more tables (context menu). Primary targets are **primaryTableIds** / **primaryLabels**; **associatedTableIds** are diagram neighbors outside that set—co-update when FKs, types, renames, or cardinality must stay aligned across the subgraph. |
+| **selectedNodeId** / **selectedEdgeId** | Canvas selection ids (may be null). |
+| **tables[]** | Non-deleted tables: **id** (node id), **label**, **columns** with **id**, **name**, **type**, **pk**, **nullable**. |
+| **relationships[]** | Edges: **id**, endpoints, **relationship** cardinality. |
+
+**Greenfield (tables is [])**: output **create_table** for each entity first, then **create_relationship**. Runtime assigns table node ids—you may reference new tables by **label** and columns by **name** in the same **operations** array; the resolver maps them.
+
+**Existing data**: prefer **tables[].id** and **columns[].id** from JSON for edits to avoid stale labels.
+
+## Response format (strict)
+One top-level JSON object only—no markdown code fences, no leading/trailing prose.
+
+{ "summary": "…", "operations": [ … ] }
+
+- **summary**: Always substantive—what changed, design rationale, assumptions, risks, or next steps. Use short markdown (bullets, **bold**). If **operations** is [], **summary** carries the full answer.
+- **operations**: Ordered steps. On doubt or unsupported requests, use **operations**: [] and explain in **summary**.
+
+## Capability catalog (five operations)
+
+**1) create_table** — Add a table.
+{ "op":"create_table", "label":"snake_case_name", "columns":[ ColumnInput, … ], "position"?:{ "x": number, "y": number } }
+- **label**: unique (case-insensitive). Prefer consistent plural entity names (**users**, **blog_posts**).
+- **columns**: at least one; include a PK (**pk**: true, **nullable**: false) unless you document why not in **summary**.
+
+**2) update_table** — Change a table.
+{ "op":"update_table", "tableId":"<tables[].id OR label>", "label"?, "columns"?, "comment"?|null }
+- **columns** if present = **full replacement** list: every surviving column must appear with its **id** preserved; new columns omit **id**.
+- Table rename: **label**. Comment only: omit **columns**; clear comment with **comment**: null.
+
+**3) delete_table** — Remove a table.
+{ "op":"delete_table", "tableId":"<id OR label>" }
+- Edges to that table are stripped; you may still **delete_relationship** first for clarity.
+
+**4) create_relationship** — Edge between two columns.
+{ "op":"create_relationship", "sourceTableId","sourceColumnId","targetTableId","targetColumnId","relationshipType":"one-to-one"|"one-to-many"|"many-to-one"|"many-to-many" }
+- Tables: **id** or **label** (including tables created earlier in this **operations** array).
+- Columns: **id** or **name** on that table.
+- **relationshipType**: match the business (FK usually on the "many" side). No duplicate edge for the same column pair.
+
+**5) delete_relationship** — Remove an edge.
+{ "op":"delete_relationship", "edgeId":"<relationships[].id>" }
+
+## ColumnInput
+{ "id"?, "name", "type", "pk"?, "nullable"?, "length"?, "precision"?, "scale"?, "comment"?, "isUnsigned"?, "isAutoIncrement"?, "isUnique"?, "defaultValue"?, "enumValues"? }
+
+**ThothBlueprint-friendly patterns**
+- **Naming**: snake_case; FKs often **user_id**-style names referencing the parent table's PK column.
+- **Surrogate PKs**: BIGINT / UUID / SERIAL family per dbType; align FK types to referenced PKs.
+- **Junction / M–M**: separate table + FK columns + two relationships to parents.
+- **Timestamps**: **created_at**, **updated_at** with appropriate **DATETIME** / **TIMESTAMPTZ** and **nullable** false where system-managed.
+
+## dbType hints
+- **mysql**: INT, BIGINT, VARCHAR, TEXT, DATETIME, TIMESTAMP, JSON, ENUM, DECIMAL, etc.
+- **postgres**: UUID, TEXT, VARCHAR, BOOLEAN, JSONB, TIMESTAMPTZ, SERIAL/BIGSERIAL, ARRAY when justified.
+
+## Operation order (discipline)
+1. create_table (new entities)  
+2. update_table (mutations)  
+3. create_relationship (endpoints must exist in the running draft)  
+4. delete_relationship → delete_table for teardowns  
+
+## Pre-flight checklist
+- Full column list on every **update_table** that sends **columns**?
+- Every **create_relationship** references tables/columns that exist or were created above?
+- FK column **type** pairs match?
+- No duplicate relationship for the same two columns?
+
+## When operations must be []
+- Questions, reviews, comparisons, or "how should I…?" with no edit.
+- Diagram **locked** (tell user to unlock).
+- Needs unsupported features—explain alternatives in **summary**.`;
+
+function parseModelJson(text: string): unknown {
+  let t = text.trim();
+  if (t.startsWith("```")) {
+    t = t
+      .replace(/^```(?:json)?\s*/i, "")
+      .replace(/\s*```$/u, "")
+      .trim();
+  }
+  return JSON.parse(t) as unknown;
+}
+
+function AiChatThinkingIndicator() {
+  return (
+    <div
+      className="flex flex-row gap-2.5"
+      aria-busy="true"
+      aria-live="polite"
+      aria-label="Assistant is thinking"
+    >
+      <div className="relative flex h-8 w-8 shrink-0 items-center justify-center">
+        <span
+          className="absolute inset-0 rounded-full bg-primary/15 animate-ping"
+          style={{ animationDuration: "2s" }}
+        />
+        <span className="relative flex h-8 w-8 items-center justify-center rounded-full bg-muted text-primary ring-2 ring-primary/20 ring-offset-2 ring-offset-background">
+          <Sparkles className="h-4 w-4" aria-hidden />
+        </span>
+      </div>
+      <div
+        className={cn(
+          "max-w-[min(100%,20rem)] rounded-2xl rounded-tl-md border border-primary/15 px-3.5 py-2.5 shadow-sm",
+          "bg-gradient-to-r from-muted/70 via-primary/[0.12] to-muted/70 bg-[length:400%_100%] animate-ai-chat-shimmer",
+        )}
+      >
+        <div className="flex flex-wrap items-center gap-2">
+          <p className="text-sm text-muted-foreground">Thinking about your schema</p>
+          <span className="flex items-center gap-1 pt-0.5" aria-hidden>
+            {[0, 1, 2].map((i) => (
+              <span
+                key={i}
+                className="h-1.5 w-1.5 rounded-full bg-primary/80 animate-ai-thinking-dot"
+                style={{ animationDelay: `${i * 140}ms` }}
+              />
+            ))}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function AiChatTab({ isLocked }: { isLocked: boolean }) {
+  const apiKeyRef = useRef<string | null>(null);
+  const chatScrollEndRef = useRef<HTMLDivElement>(null);
+  const [keyModalOpen, setKeyModalOpen] = useState(false);
+  const [sessionUnlocked, setSessionUnlocked] = useState(false);
+  const [messages, setMessages] = useState<AiChatMessage[]>([]);
+  const [chatHydrated, setChatHydrated] = useState(false);
+  const [draft, setDraft] = useState("");
+  const [sending, setSending] = useState(false);
+
+  const [storedKeyPresent, setStoredKeyPresent] = useState(() =>
+    hasEncryptedGeminiKey(),
+  );
+
+  useEffect(() => {
+    const k = loadGeminiKeyFromSession();
+    if (k) {
+      apiKeyRef.current = k;
+      setSessionUnlocked(true);
+    }
+  }, []);
+
+  const {
+    diagram,
+    selectedNodeId,
+    selectedEdgeId,
+    aiChatPinnedTableIds,
+    removeAiChatPinnedTable,
+    setAiChatPinnedTableIds,
+    applyAiDiagramOperations,
+  } = useStore(
+    useShallow((s) => {
+      const d = s.selectedDiagramId
+        ? s.diagramsMap.get(s.selectedDiagramId)
+        : undefined;
+      return {
+        diagram: d,
+        selectedNodeId: s.selectedNodeId,
+        selectedEdgeId: s.selectedEdgeId,
+        aiChatPinnedTableIds: s.aiChatPinnedTableIds,
+        removeAiChatPinnedTable: s.removeAiChatPinnedTable,
+        setAiChatPinnedTableIds: s.setAiChatPinnedTableIds,
+        applyAiDiagramOperations: s.applyAiDiagramOperations,
+      };
+    }),
+  );
+
+  const pinnedTablesForChips = useMemo(() => {
+    if (!diagram?.data.nodes?.length || !aiChatPinnedTableIds.length) return [];
+    const byId = new Map(diagram.data.nodes.map((n) => [n.id, n]));
+    const out: { id: string; label: string }[] = [];
+    for (const id of aiChatPinnedTableIds) {
+      const n = byId.get(id);
+      if (n?.type === "table" && !n.data.isDeleted) {
+        out.push({ id, label: n.data.label });
+      }
+    }
+    return out;
+  }, [diagram, aiChatPinnedTableIds]);
+
+  useEffect(() => {
+    if (!diagram?.data.nodes || aiChatPinnedTableIds.length === 0) return;
+    const valid = new Set(
+      diagram.data.nodes
+        .filter((n) => n.type === "table" && !n.data.isDeleted)
+        .map((n) => n.id),
+    );
+    const next = aiChatPinnedTableIds.filter((id) => valid.has(id));
+    if (next.length !== aiChatPinnedTableIds.length) {
+      setAiChatPinnedTableIds(next);
+    }
+  }, [diagram, aiChatPinnedTableIds, setAiChatPinnedTableIds]);
+
+  const diagramId = diagram?.id;
+
+  useEffect(() => {
+    setChatHydrated(false);
+    if (diagramId == null) {
+      setMessages([]);
+      setChatHydrated(true);
+      return;
+    }
+    let cancelled = false;
+    void loadAiChatHistory(diagramId)
+      .then((loaded) => {
+        if (!cancelled) {
+          setMessages(loaded);
+          setChatHydrated(true);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setMessages([]);
+          setChatHydrated(true);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [diagramId]);
+
+  useEffect(() => {
+    if (!chatHydrated || diagramId == null) return;
+    const t = window.setTimeout(() => {
+      void saveAiChatHistory(diagramId, messages);
+    }, 300);
+    return () => window.clearTimeout(t);
+  }, [chatHydrated, diagramId, messages]);
+
+  useEffect(() => {
+    if (!chatHydrated) return;
+    if (messages.length === 0 && !sending) return;
+    const id = requestAnimationFrame(() => {
+      chatScrollEndRef.current?.scrollIntoView({
+        behavior: "smooth",
+        block: "end",
+      });
+    });
+    return () => cancelAnimationFrame(id);
+  }, [chatHydrated, messages, sending]);
+
+  const pinnedLabelsPhrase = useMemo(
+    () => pinnedTablesForChips.map((p) => `"${p.label}"`).join(", "),
+    [pinnedTablesForChips],
+  );
+
+  const contextJson = useMemo(() => {
+    if (!diagram) return "";
+    const ctx = buildDiagramContext(
+      diagram.data,
+      diagram.dbType,
+      selectedNodeId,
+      selectedEdgeId,
+      aiChatPinnedTableIds,
+    );
+    return diagramContextToPromptJson(ctx);
+  }, [
+    diagram,
+    selectedNodeId,
+    selectedEdgeId,
+    aiChatPinnedTableIds,
+  ]);
+
+  const keyStatus = useMemo(() => {
+    if (!storedKeyPresent) {
+      return {
+        label: "No API key",
+        variant: "secondary" as const,
+        className:
+          "border-transparent bg-muted text-muted-foreground hover:bg-muted",
+      };
+    }
+    if (!sessionUnlocked) {
+      return {
+        label: "Saved · unlock to chat",
+        variant: "outline" as const,
+        className:
+          "border-amber-500/35 bg-amber-500/[0.12] text-amber-950 dark:text-amber-100",
+      };
+    }
+    return {
+      label: "Ready",
+      variant: "default" as const,
+      className: "",
+    };
+  }, [storedKeyPresent, sessionUnlocked]);
+
+  const sendMessage = useCallback(async () => {
+    const text = draft.trim();
+    if (!text || !diagram) return;
+    if (isLocked) {
+      showError("Diagram is locked.");
+      return;
+    }
+    const key = apiKeyRef.current;
+    if (!key) {
+      showError("Add your API key in settings.");
+      setKeyModalOpen(true);
+      return;
+    }
+
+    setDraft("");
+    const userMessage = text;
+    setMessages((m) => [...m, { role: "user", content: userMessage }]);
+    setSending(true);
+
+    try {
+      const history: { role: "user" | "model"; text: string }[] =
+        messages.map((msg) => ({
+          role: msg.role,
+          text: msg.content,
+        }));
+
+      const scopeHint =
+        pinnedLabelsPhrase.length > 0
+          ? `The user scoped this chat to these tables: ${pinnedLabelsPhrase}, including their diagram neighbors (see aiChatTarget in the JSON). Prefer coordinated schema updates across that subgraph when relevant.\n\n`
+          : "";
+
+      const augmentedUser = `${userMessage}
+
+${scopeHint}Below is the live diagram snapshot — use it as the only source of truth for ids and column types. If "editorFocus" or "aiChatTarget" is set, treat them as intent anchors when the message is underspecified.
+
+Current diagram (JSON):
+${contextJson}`;
+
+      const rawText = await callGeminiDiagramAssistant({
+        apiKey: key,
+        systemInstruction: SYSTEM_INSTRUCTION,
+        history,
+        userMessage: augmentedUser,
+      });
+
+      let parsed: unknown;
+      try {
+        parsed = parseModelJson(rawText);
+      } catch {
+        showError("Model did not return valid JSON.");
+        setMessages((m) => [
+          ...m,
+          {
+            role: "model",
+            content:
+              "Sorry, I could not parse the model response as JSON. Raw output:\n\n```\n" +
+              rawText.slice(0, 2000) +
+              (rawText.length > 2000 ? "\n…" : "") +
+              "\n```",
+          },
+        ]);
+        return;
+      }
+
+      const applyResult = applyAiDiagramOperations(parsed);
+      if (!applyResult.ok) {
+        showError(applyResult.error);
+        const summary =
+          typeof parsed === "object" &&
+          parsed !== null &&
+          "summary" in parsed &&
+          typeof (parsed as { summary?: unknown }).summary === "string"
+            ? (parsed as { summary: string }).summary
+            : null;
+        setMessages((m) => [
+          ...m,
+          {
+            role: "model",
+            content:
+              (summary ? `${summary}\n\n` : "") +
+              `**Changes were not applied:** ${applyResult.error}`,
+          },
+        ]);
+        return;
+      }
+
+      const opCount =
+        parsed &&
+        typeof parsed === "object" &&
+        parsed !== null &&
+        "operations" in parsed &&
+        Array.isArray((parsed as { operations: unknown }).operations)
+          ? (parsed as { operations: unknown[] }).operations.length
+          : 0;
+
+      const appliedSummary = applyResult.summary?.trim();
+      const appliedNote =
+        appliedSummary ??
+        (opCount === 0
+          ? "No diagram changes in this response."
+          : "Changes applied to the diagram.");
+
+      setMessages((m) => [
+        ...m,
+        { role: "model", content: appliedNote || "Done." },
+      ]);
+      if (opCount > 0) {
+        showSuccess("Diagram updated.");
+      }
+    } catch (e) {
+      console.error(e);
+      const msg = e instanceof Error ? e.message : "Request failed.";
+      showError(msg);
+      setMessages((m) => [
+        ...m,
+        {
+          role: "model",
+          content: `Request failed: ${msg}`,
+        },
+      ]);
+    } finally {
+      setSending(false);
+    }
+  }, [
+    draft,
+    diagram,
+    isLocked,
+    messages,
+    contextJson,
+    applyAiDiagramOperations,
+    pinnedLabelsPhrase,
+  ]);
+
+  if (!diagram) return null;
+
+  const canSend =
+    !isLocked && !sending && draft.trim().length > 0 && sessionUnlocked;
+
+  let textareaPlaceholder = "Ask for tables, columns, or relationships…";
+  if (isLocked) {
+    textareaPlaceholder = "Unlock diagram to chat…";
+  } else if (!sessionUnlocked) {
+    textareaPlaceholder = "Unlock your API key to start…";
+  } else if (pinnedTablesForChips.length === 1) {
+    const label = pinnedTablesForChips.at(0)?.label ?? "this table";
+    textareaPlaceholder = `Describe changes to "${label}" or its related tables…`;
+  } else if (pinnedTablesForChips.length > 1) {
+    textareaPlaceholder =
+      "Describe changes to the pinned tables and their related tables…";
+  }
+
+  return (
+    <>
+      <GeminiKeyModal
+        open={keyModalOpen}
+        onOpenChange={setKeyModalOpen}
+        storedKeyPresent={storedKeyPresent}
+        onStoredKeyChange={setStoredKeyPresent}
+        sessionUnlocked={sessionUnlocked}
+        onSessionUnlockedChange={setSessionUnlocked}
+        apiKeyRef={apiKeyRef}
+      />
+
+      <div className="flex h-full min-h-0 flex-col">
+        <div className="shrink-0 border-b bg-gradient-to-b from-primary/[0.06] to-transparent px-4 py-3">
+          <div className="flex items-start gap-3">
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary ring-1 ring-primary/15">
+              <Sparkles className="h-5 w-5" aria-hidden />
+            </div>
+            <div className="min-w-0 flex-1 space-y-2">
+              <div className="flex flex-wrap items-center gap-2">
+                <h2 className="text-sm font-semibold tracking-tight">
+                  Schema assistant
+                </h2>
+                <Badge
+                  variant={keyStatus.variant}
+                  className={cn("font-normal", keyStatus.className)}
+                >
+                  {keyStatus.label}
+                </Badge>
+                <Badge
+                  variant="outline"
+                  className="max-w-[14rem] truncate border-border/80 font-mono text-[10px] font-normal text-muted-foreground"
+                  title={GEMINI_DIAGRAM_MODEL}
+                  aria-label={`AI model: ${GEMINI_DIAGRAM_MODEL}`}
+                >
+                  {GEMINI_DIAGRAM_MODEL}
+                </Badge>
+              </div>
+              <p className="text-[11px] leading-snug text-muted-foreground">
+                Powered by Google Gemini. After you unlock once, you stay signed in for
+                this tab until you lock or close it. Diagram data is sent with
+                each message.
+              </p>
+              <div className="flex flex-wrap gap-2 pt-0.5">
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="sm"
+                  className="h-8 gap-1.5 text-xs"
+                  onClick={() => setKeyModalOpen(true)}
+                >
+                  <Settings2 className="h-3.5 w-3.5" />
+                  API key
+                </Button>
+                {storedKeyPresent && !sessionUnlocked && (
+                  <Button
+                    type="button"
+                    size="sm"
+                    className="h-8 gap-1.5 text-xs"
+                    onClick={() => setKeyModalOpen(true)}
+                  >
+                    <Lock className="h-3.5 w-3.5" />
+                    Unlock
+                  </Button>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <ScrollArea className="min-h-0 flex-1">
+          <div className="space-y-4 p-4 pb-2">
+            {messages.length === 0 && !sending ? (
+              <div className="rounded-2xl border border-dashed bg-muted/20 px-4 py-10 text-center">
+                <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-muted/80 text-muted-foreground">
+                  <Bot className="h-6 w-6" />
+                </div>
+                <p className="text-sm font-medium text-foreground">
+                  Describe what to add or change
+                </p>
+                <p className="mx-auto mt-1 max-w-[240px] text-xs text-muted-foreground leading-relaxed">
+                  For example: add a{" "}
+                  <span className="font-mono text-[11px]">users</span> table
+                  with id and email, or link{" "}
+                  <span className="font-mono text-[11px]">orders</span> to{" "}
+                  <span className="font-mono text-[11px]">users</span>.
+                </p>
+                {!storedKeyPresent && (
+                  <Button
+                    type="button"
+                    size="sm"
+                    className="mt-4"
+                    onClick={() => setKeyModalOpen(true)}
+                  >
+                    Add API key
+                  </Button>
+                )}
+              </div>
+            ) : (
+              <>
+                {messages.map((msg, i) => (
+                  <div
+                    key={i}
+                    className={cn(
+                      "flex gap-2.5",
+                      msg.role === "user" ? "flex-row-reverse" : "flex-row",
+                    )}
+                  >
+                    <div
+                      className={cn(
+                        "flex h-8 w-8 shrink-0 items-center justify-center rounded-full",
+                        msg.role === "user"
+                          ? "bg-primary text-primary-foreground"
+                          : "bg-muted text-muted-foreground",
+                      )}
+                    >
+                      {msg.role === "user" ? (
+                        <User className="h-4 w-4" />
+                      ) : (
+                        <Bot className="h-4 w-4" />
+                      )}
+                    </div>
+                    <div
+                      className={cn(
+                        "max-w-[min(100%,20rem)] rounded-2xl px-3.5 py-2.5 text-sm shadow-sm",
+                        msg.role === "user"
+                          ? "bg-primary text-primary-foreground rounded-tr-md"
+                          : "border bg-card rounded-tl-md prose prose-sm dark:prose-invert max-w-none prose-p:my-1 prose-headings:my-2",
+                      )}
+                    >
+                      {msg.role === "model" ? (
+                        <Markdown remarkPlugins={[remarkGfm]}>
+                          {msg.content}
+                        </Markdown>
+                      ) : (
+                        <p className="whitespace-pre-wrap break-words leading-relaxed">
+                          {msg.content}
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                ))}
+                {sending && <AiChatThinkingIndicator />}
+                <div
+                  ref={chatScrollEndRef}
+                  className="h-px w-full shrink-0"
+                  aria-hidden
+                />
+              </>
+            )}
+          </div>
+        </ScrollArea>
+
+        <div className="shrink-0 border-t bg-card/80 p-3 backdrop-blur-sm">
+          {pinnedTablesForChips.length > 0 && (
+            <div className="mb-2 space-y-2">
+              <div className="flex flex-wrap gap-2">
+                {pinnedTablesForChips.map(({ id: tableId, label }) => (
+                  <div
+                    key={tableId}
+                    className="inline-flex max-w-full items-center gap-1 rounded-full border bg-muted/40 pl-2.5 text-xs shadow-sm"
+                  >
+                    <Sparkles
+                      className="h-3 w-3 shrink-0 text-primary"
+                      aria-hidden
+                    />
+                    <span className="truncate font-medium">{label}</span>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      className="h-7 w-7 shrink-0 rounded-full"
+                      onClick={() => removeAiChatPinnedTable(tableId)}
+                      aria-label={`Remove ${label} from AI chat scope`}
+                    >
+                      <X className="h-3.5 w-3.5" />
+                    </Button>
+                  </div>
+                ))}
+              </div>
+              <p className="text-[10px] leading-snug text-muted-foreground">
+                Scoped to these tables and their linked neighbors on the diagram.
+              </p>
+            </div>
+          )}
+          <div
+            className={cn(
+              "flex gap-2 rounded-2xl border bg-background p-2 shadow-sm ring-offset-background focus-within:ring-2 focus-within:ring-ring/30",
+              isLocked && "opacity-60",
+            )}
+          >
+            <Textarea
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              placeholder={textareaPlaceholder}
+              disabled={isLocked || sending || !sessionUnlocked}
+              className="min-h-[44px] max-h-32 flex-1 resize-none border-0 bg-transparent px-2 py-2 text-sm shadow-none focus-visible:ring-0"
+              rows={2}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+                  e.preventDefault();
+                  void sendMessage();
+                }
+              }}
+            />
+            <Button
+              type="button"
+              size="icon"
+              disabled={!canSend}
+              className="h-11 w-11 shrink-0 rounded-xl"
+              onClick={() => void sendMessage()}
+              aria-label="Send message"
+            >
+              {sending ? (
+                <Loader2 className="h-5 w-5 animate-spin" />
+              ) : (
+                <SendHorizontal className="h-5 w-5" />
+              )}
+            </Button>
+          </div>
+          <p className="mt-2 text-center text-[10px] text-muted-foreground">
+            ⌘/Ctrl + Enter to send · do not paste secrets
+          </p>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/AiChatTab.tsx
+++ b/src/components/AiChatTab.tsx
@@ -20,6 +20,7 @@ import { showError, showSuccess } from "@/utils/toast";
 import { cn } from "@/lib/utils";
 import {
   Bot,
+  CircleHelp,
   Loader2,
   Lock,
   SendHorizontal,
@@ -35,6 +36,7 @@ import { useShallow } from "zustand/react/shallow";
 import { GeminiKeyModal } from "./GeminiKeyModal";
 import { Badge } from "./ui/badge";
 import { Button } from "./ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
 import { ScrollArea } from "./ui/scroll-area";
 import { Textarea } from "./ui/textarea";
 
@@ -175,7 +177,15 @@ function AiChatThinkingIndicator() {
   );
 }
 
-export default function AiChatTab({ isLocked }: { isLocked: boolean }) {
+export default function AiChatTab({
+  isLocked,
+  onRequestClose,
+  variant = "sidebar",
+}: {
+  isLocked: boolean;
+  onRequestClose?: () => void;
+  variant?: "sidebar" | "floating";
+}) {
   const apiKeyRef = useRef<string | null>(null);
   const chatScrollEndRef = useRef<HTMLDivElement>(null);
   const [keyModalOpen, setKeyModalOpen] = useState(false);
@@ -493,6 +503,90 @@ ${contextJson}`;
       "Describe changes to the pinned tables and their related tables…";
   }
 
+  const messageList = (
+    <div className="space-y-4 p-4 pb-2">
+      {messages.length === 0 && !sending ? (
+        <div className="rounded-2xl border border-dashed bg-muted/20 px-4 py-10 text-center">
+          <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-muted/80 text-muted-foreground">
+            <Bot className="h-6 w-6" />
+          </div>
+          <p className="text-sm font-medium text-foreground">
+            Describe what to add or change
+          </p>
+          <p className="mx-auto mt-1 max-w-[240px] text-xs text-muted-foreground leading-relaxed">
+            For example: add a{" "}
+            <span className="font-mono text-[11px]">users</span> table with id
+            and email, or link{" "}
+            <span className="font-mono text-[11px]">orders</span> to{" "}
+            <span className="font-mono text-[11px]">users</span>.
+          </p>
+          {!storedKeyPresent && (
+            <Button
+              type="button"
+              size="sm"
+              className="mt-4"
+              onClick={() => setKeyModalOpen(true)}
+            >
+              Add API key
+            </Button>
+          )}
+        </div>
+      ) : (
+        <>
+          {messages.map((msg, i) => (
+            <div
+              key={i}
+              className={cn(
+                "flex gap-2.5",
+                msg.role === "user" ? "flex-row-reverse" : "flex-row",
+              )}
+            >
+              <div
+                className={cn(
+                  "flex h-8 w-8 shrink-0 items-center justify-center rounded-full",
+                  msg.role === "user"
+                    ? "bg-primary text-primary-foreground"
+                    : "bg-muted text-muted-foreground",
+                )}
+              >
+                {msg.role === "user" ? (
+                  <User className="h-4 w-4" />
+                ) : (
+                  <Bot className="h-4 w-4" />
+                )}
+              </div>
+              <div
+                className={cn(
+                  "rounded-2xl px-3.5 py-2.5 text-sm shadow-sm",
+                  variant === "floating"
+                    ? "max-w-[min(100%,26rem)]"
+                    : "max-w-[min(100%,20rem)]",
+                  msg.role === "user"
+                    ? "bg-primary text-primary-foreground rounded-tr-md"
+                    : "border bg-card rounded-tl-md prose prose-sm dark:prose-invert max-w-none prose-p:my-1 prose-headings:my-2",
+                )}
+              >
+                {msg.role === "model" ? (
+                  <Markdown remarkPlugins={[remarkGfm]}>{msg.content}</Markdown>
+                ) : (
+                  <p className="whitespace-pre-wrap break-words leading-relaxed">
+                    {msg.content}
+                  </p>
+                )}
+              </div>
+            </div>
+          ))}
+          {sending && <AiChatThinkingIndicator />}
+          <div
+            ref={chatScrollEndRef}
+            className="h-px w-full shrink-0"
+            aria-hidden
+          />
+        </>
+      )}
+    </div>
+  );
+
   return (
     <>
       <GeminiKeyModal
@@ -506,145 +600,193 @@ ${contextJson}`;
       />
 
       <div className="flex h-full min-h-0 flex-col">
-        <div className="shrink-0 border-b bg-gradient-to-b from-primary/[0.06] to-transparent px-4 py-3">
-          <div className="flex items-start gap-3">
-            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary ring-1 ring-primary/15">
-              <Sparkles className="h-5 w-5" aria-hidden />
-            </div>
-            <div className="min-w-0 flex-1 space-y-2">
-              <div className="flex flex-wrap items-center gap-2">
-                <h2 className="text-sm font-semibold tracking-tight">
+        {variant === "floating" ? (
+          <>
+            <div className="shrink-0 border-b bg-gradient-to-b from-primary/[0.06] to-transparent px-2 py-2 sm:px-3">
+              <div className="flex min-w-0 items-center gap-1">
+                <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary ring-1 ring-primary/15">
+                  <Sparkles className="h-4 w-4" aria-hidden />
+                </div>
+                <h2 className="min-w-0 flex-1 truncate text-sm font-semibold tracking-tight">
                   Schema assistant
                 </h2>
                 <Badge
                   variant={keyStatus.variant}
-                  className={cn("font-normal", keyStatus.className)}
+                  className={cn(
+                    "shrink-0 px-1.5 py-0 text-[10px] font-normal",
+                    keyStatus.className,
+                  )}
                 >
                   {keyStatus.label}
                 </Badge>
-                <Badge
-                  variant="outline"
-                  className="max-w-[14rem] truncate border-border/80 font-mono text-[10px] font-normal text-muted-foreground"
-                  title={GEMINI_DIAGRAM_MODEL}
-                  aria-label={`AI model: ${GEMINI_DIAGRAM_MODEL}`}
-                >
-                  {GEMINI_DIAGRAM_MODEL}
-                </Badge>
-              </div>
-              <p className="text-[11px] leading-snug text-muted-foreground">
-                Powered by Google Gemini. After you unlock once, you stay signed in for
-                this tab until you lock or close it. Diagram data is sent with
-                each message.
-              </p>
-              <div className="flex flex-wrap gap-2 pt-0.5">
+                <Popover>
+                  <PopoverTrigger asChild>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      className="h-8 w-8 shrink-0 text-muted-foreground"
+                      aria-label="Privacy, disclaimers, and data"
+                    >
+                      <CircleHelp className="h-4 w-4" />
+                    </Button>
+                  </PopoverTrigger>
+                  <PopoverContent
+                    align="end"
+                    side="bottom"
+                    className="w-80 max-w-[min(22rem,calc(100vw-2rem))] space-y-3 text-xs"
+                  >
+                    <div>
+                      <p className="mb-1 font-medium text-foreground">Model</p>
+                      <p
+                        className="break-all font-mono text-[10px] text-muted-foreground"
+                        title={GEMINI_DIAGRAM_MODEL}
+                      >
+                        {GEMINI_DIAGRAM_MODEL}
+                      </p>
+                    </div>
+                    <p className="leading-relaxed text-muted-foreground">
+                      Powered by Google Gemini. After you unlock once, you stay
+                      signed in for this session until you lock or close the
+                      browser tab. Each message includes a snapshot of your
+                      diagram so the assistant can suggest schema changes.
+                    </p>
+                    <div className="border-t pt-3">
+                      <p className="mb-1.5 font-medium text-foreground">
+                        Accuracy
+                      </p>
+                      <p className="leading-relaxed text-muted-foreground">
+                        AI can make mistakes—review suggestions and diagram
+                        changes before relying on them.
+                      </p>
+                    </div>
+                    <div>
+                      <p className="mb-1.5 font-medium text-foreground">
+                        Chat history
+                      </p>
+                      <p className="leading-relaxed text-muted-foreground">
+                        History is saved only on this device for this diagram;
+                        it is not synced and may be lost if you clear site
+                        data.
+                      </p>
+                    </div>
+                  </PopoverContent>
+                </Popover>
                 <Button
                   type="button"
-                  variant="secondary"
-                  size="sm"
-                  className="h-8 gap-1.5 text-xs"
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8 shrink-0"
                   onClick={() => setKeyModalOpen(true)}
+                  aria-label="API key settings"
                 >
-                  <Settings2 className="h-3.5 w-3.5" />
-                  API key
+                  <Settings2 className="h-4 w-4" />
                 </Button>
-                {storedKeyPresent && !sessionUnlocked && (
+                {storedKeyPresent && !sessionUnlocked ? (
                   <Button
                     type="button"
-                    size="sm"
-                    className="h-8 gap-1.5 text-xs"
+                    variant="ghost"
+                    size="icon"
+                    className="h-8 w-8 shrink-0 text-amber-600 dark:text-amber-400"
                     onClick={() => setKeyModalOpen(true)}
+                    aria-label="Unlock API key"
                   >
-                    <Lock className="h-3.5 w-3.5" />
-                    Unlock
+                    <Lock className="h-4 w-4" />
                   </Button>
-                )}
+                ) : null}
+                {onRequestClose ? (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="h-8 w-8 shrink-0 text-muted-foreground hover:text-foreground"
+                    onClick={onRequestClose}
+                    aria-label="Close assistant"
+                  >
+                    <X className="h-4 w-4" />
+                  </Button>
+                ) : null}
               </div>
             </div>
-          </div>
-        </div>
-
-        <ScrollArea className="min-h-0 flex-1">
-          <div className="space-y-4 p-4 pb-2">
-            {messages.length === 0 && !sending ? (
-              <div className="rounded-2xl border border-dashed bg-muted/20 px-4 py-10 text-center">
-                <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-muted/80 text-muted-foreground">
-                  <Bot className="h-6 w-6" />
+            <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain">
+              {messageList}
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="shrink-0 border-b bg-gradient-to-b from-primary/[0.06] to-transparent px-4 py-3">
+              <div className="flex items-start gap-3">
+                <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary ring-1 ring-primary/15">
+                  <Sparkles className="h-5 w-5" aria-hidden />
                 </div>
-                <p className="text-sm font-medium text-foreground">
-                  Describe what to add or change
-                </p>
-                <p className="mx-auto mt-1 max-w-[240px] text-xs text-muted-foreground leading-relaxed">
-                  For example: add a{" "}
-                  <span className="font-mono text-[11px]">users</span> table
-                  with id and email, or link{" "}
-                  <span className="font-mono text-[11px]">orders</span> to{" "}
-                  <span className="font-mono text-[11px]">users</span>.
-                </p>
-                {!storedKeyPresent && (
+                <div className="min-w-0 flex-1 space-y-2 pr-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <h2 className="text-sm font-semibold tracking-tight">
+                      Schema assistant
+                    </h2>
+                    <Badge
+                      variant={keyStatus.variant}
+                      className={cn("font-normal", keyStatus.className)}
+                    >
+                      {keyStatus.label}
+                    </Badge>
+                    <Badge
+                      variant="outline"
+                      className="max-w-[14rem] truncate border-border/80 font-mono text-[10px] font-normal text-muted-foreground"
+                      title={GEMINI_DIAGRAM_MODEL}
+                      aria-label={`AI model: ${GEMINI_DIAGRAM_MODEL}`}
+                    >
+                      {GEMINI_DIAGRAM_MODEL}
+                    </Badge>
+                  </div>
+                  <p className="text-[11px] leading-snug text-muted-foreground">
+                    Powered by Google Gemini. After you unlock once, you stay
+                    signed in for this tab until you lock or close it. Diagram
+                    data is sent with each message.
+                  </p>
+                  <div className="flex flex-wrap gap-2 pt-0.5">
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      size="sm"
+                      className="h-8 gap-1.5 text-xs"
+                      onClick={() => setKeyModalOpen(true)}
+                    >
+                      <Settings2 className="h-3.5 w-3.5" />
+                      API key
+                    </Button>
+                    {storedKeyPresent && !sessionUnlocked && (
+                      <Button
+                        type="button"
+                        size="sm"
+                        className="h-8 gap-1.5 text-xs"
+                        onClick={() => setKeyModalOpen(true)}
+                      >
+                        <Lock className="h-3.5 w-3.5" />
+                        Unlock
+                      </Button>
+                    )}
+                  </div>
+                </div>
+                {onRequestClose ? (
                   <Button
                     type="button"
-                    size="sm"
-                    className="mt-4"
-                    onClick={() => setKeyModalOpen(true)}
+                    variant="ghost"
+                    size="icon"
+                    className="h-9 w-9 shrink-0 text-muted-foreground hover:text-foreground"
+                    onClick={onRequestClose}
+                    aria-label="Close assistant"
                   >
-                    Add API key
+                    <X className="h-4 w-4" />
                   </Button>
-                )}
+                ) : null}
               </div>
-            ) : (
-              <>
-                {messages.map((msg, i) => (
-                  <div
-                    key={i}
-                    className={cn(
-                      "flex gap-2.5",
-                      msg.role === "user" ? "flex-row-reverse" : "flex-row",
-                    )}
-                  >
-                    <div
-                      className={cn(
-                        "flex h-8 w-8 shrink-0 items-center justify-center rounded-full",
-                        msg.role === "user"
-                          ? "bg-primary text-primary-foreground"
-                          : "bg-muted text-muted-foreground",
-                      )}
-                    >
-                      {msg.role === "user" ? (
-                        <User className="h-4 w-4" />
-                      ) : (
-                        <Bot className="h-4 w-4" />
-                      )}
-                    </div>
-                    <div
-                      className={cn(
-                        "max-w-[min(100%,20rem)] rounded-2xl px-3.5 py-2.5 text-sm shadow-sm",
-                        msg.role === "user"
-                          ? "bg-primary text-primary-foreground rounded-tr-md"
-                          : "border bg-card rounded-tl-md prose prose-sm dark:prose-invert max-w-none prose-p:my-1 prose-headings:my-2",
-                      )}
-                    >
-                      {msg.role === "model" ? (
-                        <Markdown remarkPlugins={[remarkGfm]}>
-                          {msg.content}
-                        </Markdown>
-                      ) : (
-                        <p className="whitespace-pre-wrap break-words leading-relaxed">
-                          {msg.content}
-                        </p>
-                      )}
-                    </div>
-                  </div>
-                ))}
-                {sending && <AiChatThinkingIndicator />}
-                <div
-                  ref={chatScrollEndRef}
-                  className="h-px w-full shrink-0"
-                  aria-hidden
-                />
-              </>
-            )}
-          </div>
-        </ScrollArea>
+            </div>
+            <ScrollArea className="h-0 min-h-0 flex-1">
+              {messageList}
+            </ScrollArea>
+          </>
+        )}
 
         <div className="shrink-0 border-t bg-card/80 p-3 backdrop-blur-sm">
           {pinnedTablesForChips.length > 0 && (

--- a/src/components/DiagramLayout.tsx
+++ b/src/components/DiagramLayout.tsx
@@ -13,6 +13,8 @@ import { type ImperativePanelHandle } from "react-resizable-panels";
 interface DiagramLayoutProps {
   sidebarContent: ReactNode;
   diagramContent: ReactNode;
+  /** Rendered above the diagram canvas (e.g. floating AI assistant). */
+  diagramOverlay?: ReactNode;
   isSidebarOpen: boolean;
   setIsSidebarOpen: (open: boolean) => void;
   handleOpenSidebar: () => void;
@@ -25,6 +27,7 @@ interface DiagramLayoutProps {
 export function DiagramLayout({
   sidebarContent,
   diagramContent,
+  diagramOverlay,
   isSidebarOpen,
   setIsSidebarOpen,
   handleOpenSidebar,
@@ -95,6 +98,7 @@ export function DiagramLayout({
             )}
 
             {diagramContent}
+            {diagramOverlay}
           </div>
         </ResizablePanel>
       </ResizablePanelGroup>

--- a/src/components/EditorSidebar.tsx
+++ b/src/components/EditorSidebar.tsx
@@ -4,8 +4,9 @@ import { cn } from "@/lib/utils";
 import { useStore } from "@/store/store";
 import { showError, showSuccess } from "@/utils/toast";
 import { formatDistanceToNow } from "date-fns";
-import { FileCode2, GitCommitHorizontal, History, Plus, Table } from "lucide-react";
+import { FileCode2, GitCommitHorizontal, History, Plus, Sparkles, Table } from "lucide-react";
 import React, { useMemo, useRef, useState } from "react";
+import AiChatTab from "./AiChatTab";
 import { CheckpointHistoryDialog } from "./CheckpointHistoryDialog";
 import DbmlTab from "./DbmlTab";
 import EditorMenubar from "./EditorMenubar";
@@ -50,6 +51,18 @@ export default function EditorSidebar({
   const listCheckpoints = useStore((state) => state.listCheckpoints);
   const restoreCheckpoint = useStore((state) => state.restoreCheckpoint);
   const createCheckpoint = useStore((state) => state.createCheckpoint);
+  const editorSidebarNavigateToken = useStore(
+    (state) => state.editorSidebarNavigateToken,
+  );
+  const editorSidebarNavigateTargetTab = useStore(
+    (state) => state.editorSidebarNavigateTargetTab,
+  );
+  const clearEditorSidebarNavigateTarget = useStore(
+    (state) => state.clearEditorSidebarNavigateTarget,
+  );
+  const aiChatTabSyncSuppressToken = useStore(
+    (state) => state.aiChatTabSyncSuppressToken,
+  );
 
   const diagram = useMemo(() =>
     diagramsMap.get(selectedDiagramId || 0),
@@ -69,6 +82,7 @@ export default function EditorSidebar({
   const manualTabOverrideRef = useRef(false);
   const previousSelectedNodeIdRef = useRef<string | null>(selectedNodeId);
   const previousSelectedEdgeIdRef = useRef<string | null>(selectedEdgeId);
+  const lastHandledAiChatSuppressTokenRef = useRef<number | null>(null);
 
   const nodes = useMemo(
     () =>
@@ -137,8 +151,33 @@ export default function EditorSidebar({
     }
   };
 
-  // Switch to appropriate tab when items are selected
   React.useEffect(() => {
+    if (!editorSidebarNavigateTargetTab) return;
+    manualTabOverrideRef.current = true;
+    setCurrentTab(editorSidebarNavigateTargetTab);
+    if (editorSidebarNavigateTargetTab === "dbml") {
+      setHasOpenedDbmlTab(true);
+    }
+    clearEditorSidebarNavigateTarget();
+  }, [
+    editorSidebarNavigateToken,
+    editorSidebarNavigateTargetTab,
+    clearEditorSidebarNavigateTarget,
+  ]);
+
+  // Switch to appropriate tab when items are selected (skip once after "Chat with AI" so we stay on AI).
+  React.useEffect(() => {
+    const prevToken = lastHandledAiChatSuppressTokenRef.current;
+    if (prevToken === null) {
+      lastHandledAiChatSuppressTokenRef.current = aiChatTabSyncSuppressToken;
+    } else if (aiChatTabSyncSuppressToken > prevToken) {
+      lastHandledAiChatSuppressTokenRef.current = aiChatTabSyncSuppressToken;
+      previousSelectedNodeIdRef.current = selectedNodeId;
+      previousSelectedEdgeIdRef.current = selectedEdgeId;
+      manualTabOverrideRef.current = true;
+      return;
+    }
+
     const selectionChanged =
       previousSelectedNodeIdRef.current !== selectedNodeId ||
       previousSelectedEdgeIdRef.current !== selectedEdgeId;
@@ -164,7 +203,14 @@ export default function EditorSidebar({
     if (hasSelectedTable && currentTab !== "tables") {
       setCurrentTab("tables");
     }
-  }, [selectedNodeId, selectedEdgeId, nodes, edges, currentTab]);
+  }, [
+    aiChatTabSyncSuppressToken,
+    selectedNodeId,
+    selectedEdgeId,
+    nodes,
+    edges,
+    currentTab,
+  ]);
 
   React.useEffect(() => {
     void refreshCheckpoints();
@@ -287,6 +333,21 @@ export default function EditorSidebar({
                 <span className="ml-2 h-2 w-2 rounded-full bg-amber-500" aria-label="DBML has unsaved changes" />
               )}
             </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => handleTabChange("ai")}
+              className={cn(
+                "flex-1 min-w-0 relative h-8 rounded-sm px-2 lg:px-3 py-1.5 text-sm font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+                currentTab === "ai"
+                  ? "bg-background text-foreground shadow-sm hover:bg-background"
+                  : "hover:bg-muted-foreground/10"
+              )}
+            >
+              <Sparkles className="h-4 w-4 mr-2 shrink-0" />
+              <span className="hidden lg:inline">AI</span>
+              <span className="lg:hidden">AI</span>
+            </Button>
           </div>
           <Button
             variant="outline"
@@ -324,6 +385,9 @@ export default function EditorSidebar({
               onDirtyChange={setIsDbmlDirty}
             />
           )}
+        </div>
+        <div className={cn("h-full", currentTab !== "ai" && "hidden")}>
+          <AiChatTab isLocked={isLocked} />
         </div>
       </div>
       <CheckpointHistoryDialog

--- a/src/components/EditorSidebar.tsx
+++ b/src/components/EditorSidebar.tsx
@@ -4,9 +4,8 @@ import { cn } from "@/lib/utils";
 import { useStore } from "@/store/store";
 import { showError, showSuccess } from "@/utils/toast";
 import { formatDistanceToNow } from "date-fns";
-import { FileCode2, GitCommitHorizontal, History, Plus, Sparkles, Table } from "lucide-react";
+import { FileCode2, GitCommitHorizontal, History, Plus, Table } from "lucide-react";
 import React, { useMemo, useRef, useState } from "react";
-import AiChatTab from "./AiChatTab";
 import { CheckpointHistoryDialog } from "./CheckpointHistoryDialog";
 import DbmlTab from "./DbmlTab";
 import EditorMenubar from "./EditorMenubar";
@@ -62,9 +61,6 @@ export default function EditorSidebar({
   const clearEditorSidebarNavigateTarget = useStore(
     (state) => state.clearEditorSidebarNavigateTarget,
   );
-  const aiChatTabSyncSuppressToken = useStore(
-    (state) => state.aiChatTabSyncSuppressToken,
-  );
 
   const diagram = useMemo(() =>
     diagramsMap.get(selectedDiagramId || 0),
@@ -86,7 +82,6 @@ export default function EditorSidebar({
   const manualTabOverrideRef = useRef(false);
   const previousSelectedNodeIdRef = useRef<string | null>(selectedNodeId);
   const previousSelectedEdgeIdRef = useRef<string | null>(selectedEdgeId);
-  const lastHandledAiChatSuppressTokenRef = useRef<number | null>(null);
 
   const nodes = useMemo(
     () =>
@@ -197,19 +192,7 @@ export default function EditorSidebar({
       },
     ];
 
-  // Switch to appropriate tab when items are selected (skip once after "Chat with AI" so we stay on AI).
   React.useEffect(() => {
-    const prevToken = lastHandledAiChatSuppressTokenRef.current;
-    if (prevToken === null) {
-      lastHandledAiChatSuppressTokenRef.current = aiChatTabSyncSuppressToken;
-    } else if (aiChatTabSyncSuppressToken > prevToken) {
-      lastHandledAiChatSuppressTokenRef.current = aiChatTabSyncSuppressToken;
-      previousSelectedNodeIdRef.current = selectedNodeId;
-      previousSelectedEdgeIdRef.current = selectedEdgeId;
-      manualTabOverrideRef.current = true;
-      return;
-    }
-
     const selectionChanged =
       previousSelectedNodeIdRef.current !== selectedNodeId ||
       previousSelectedEdgeIdRef.current !== selectedEdgeId;
@@ -235,14 +218,7 @@ export default function EditorSidebar({
     if (hasSelectedTable && currentTab !== "tables") {
       setCurrentTab("tables");
     }
-  }, [
-    aiChatTabSyncSuppressToken,
-    selectedNodeId,
-    selectedEdgeId,
-    nodes,
-    edges,
-    currentTab,
-  ]);
+  }, [selectedNodeId, selectedEdgeId, nodes, edges, currentTab]);
 
   React.useEffect(() => {
     void refreshCheckpoints();
@@ -402,9 +378,6 @@ export default function EditorSidebar({
               onDirtyChange={setIsDbmlDirty}
             />
           )}
-        </div>
-        <div className={cn("h-full", currentTab !== "ai" && "hidden")}>
-          <AiChatTab isLocked={isLocked} />
         </div>
       </div>
       <CheckpointHistoryDialog

--- a/src/components/GeminiKeyModal.tsx
+++ b/src/components/GeminiKeyModal.tsx
@@ -1,0 +1,270 @@
+import {
+  clearEncryptedGeminiKey,
+  clearGeminiKeySession,
+  decryptGeminiKey,
+  saveEncryptedGeminiKey,
+  saveGeminiKeyToSession,
+} from "@/lib/ai/geminiEncryptedStorage";
+import { showError, showSuccess } from "@/utils/toast";
+import { ExternalLink } from "lucide-react";
+import {
+  useCallback,
+  useEffect,
+  useState,
+  type MutableRefObject,
+} from "react";
+import { Button } from "./ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "./ui/dialog";
+import { Input } from "./ui/input";
+import { Label } from "./ui/label";
+
+type GeminiKeyModalProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  storedKeyPresent: boolean;
+  onStoredKeyChange: (present: boolean) => void;
+  sessionUnlocked: boolean;
+  onSessionUnlockedChange: (unlocked: boolean) => void;
+  apiKeyRef: MutableRefObject<string | null>;
+};
+
+export function GeminiKeyModal({
+  open,
+  onOpenChange,
+  storedKeyPresent,
+  onStoredKeyChange,
+  sessionUnlocked,
+  onSessionUnlockedChange,
+  apiKeyRef,
+}: GeminiKeyModalProps) {
+  const [apiKey, setApiKey] = useState("");
+  const [passphraseSave, setPassphraseSave] = useState("");
+  const [passphraseUnlock, setPassphraseUnlock] = useState("");
+
+  useEffect(() => {
+    if (!open) {
+      setApiKey("");
+      setPassphraseSave("");
+      setPassphraseUnlock("");
+    }
+  }, [open]);
+
+  const handleSave = useCallback(async () => {
+    const k = apiKey.trim();
+    if (!k || !passphraseSave) {
+      showError("Enter your API key and a passphrase.");
+      return;
+    }
+    try {
+      await saveEncryptedGeminiKey(k, passphraseSave);
+      apiKeyRef.current = k;
+      saveGeminiKeyToSession(k);
+      onSessionUnlockedChange(true);
+      onStoredKeyChange(true);
+      showSuccess("Key saved and unlocked on this device.");
+      onOpenChange(false);
+    } catch (e) {
+      console.error(e);
+      showError("Could not save the key.");
+    }
+  }, [
+    apiKey,
+    passphraseSave,
+    apiKeyRef,
+    onSessionUnlockedChange,
+    onStoredKeyChange,
+    onOpenChange,
+  ]);
+
+  const handleUnlock = useCallback(async () => {
+    if (!passphraseUnlock) {
+      showError("Enter your passphrase.");
+      return;
+    }
+    try {
+      const k = await decryptGeminiKey(passphraseUnlock);
+      apiKeyRef.current = k;
+      saveGeminiKeyToSession(k);
+      onSessionUnlockedChange(true);
+      showSuccess("Ready to chat.");
+      onOpenChange(false);
+    } catch (e) {
+      console.error(e);
+      showError(
+        e instanceof Error ? e.message : "Could not unlock the key.",
+      );
+    }
+  }, [passphraseUnlock, apiKeyRef, onSessionUnlockedChange, onOpenChange]);
+
+  const handleLockMemory = useCallback(() => {
+    clearGeminiKeySession();
+    apiKeyRef.current = null;
+    onSessionUnlockedChange(false);
+    showSuccess(
+      "Key cleared for this tab. Unlock again to chat, or close the tab to clear the session.",
+    );
+    onOpenChange(false);
+  }, [apiKeyRef, onSessionUnlockedChange, onOpenChange]);
+
+  const handleRemoveStored = useCallback(() => {
+    clearEncryptedGeminiKey();
+    apiKeyRef.current = null;
+    onSessionUnlockedChange(false);
+    onStoredKeyChange(false);
+    showSuccess("Saved key removed from this browser.");
+    onOpenChange(false);
+  }, [apiKeyRef, onSessionUnlockedChange, onStoredKeyChange, onOpenChange]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md gap-0 overflow-hidden p-0">
+        <div className="border-b bg-muted/40 px-6 py-4">
+          <DialogHeader className="gap-1 text-left space-y-1">
+            <DialogTitle>Gemini API key</DialogTitle>
+            <DialogDescription className="text-xs leading-relaxed">
+              Your key is encrypted with your passphrase and kept in this
+              browser only.{" "}
+              <a
+                href="https://aistudio.google.com/apikey"
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center gap-0.5 font-medium text-foreground underline underline-offset-2 hover:text-primary"
+              >
+                Get a key
+                <ExternalLink className="h-3 w-3" aria-hidden />
+              </a>
+            </DialogDescription>
+          </DialogHeader>
+        </div>
+
+        <div className="space-y-5 px-6 py-5">
+          {!storedKeyPresent ? (
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="gemini-key">API key</Label>
+                <Input
+                  id="gemini-key"
+                  type="password"
+                  autoComplete="off"
+                  placeholder="Paste your key"
+                  value={apiKey}
+                  onChange={(e) => setApiKey(e.target.value)}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="gemini-pass-new">Passphrase</Label>
+                <Input
+                  id="gemini-pass-new"
+                  type="password"
+                  autoComplete="new-password"
+                  placeholder="Encrypts the key on this device"
+                  value={passphraseSave}
+                  onChange={(e) => setPassphraseSave(e.target.value)}
+                />
+              </div>
+            </div>
+          ) : (
+            <div className="space-y-4">
+              {!sessionUnlocked ? (
+                <div className="space-y-2">
+                  <Label htmlFor="gemini-pass-unlock">Passphrase</Label>
+                  <Input
+                    id="gemini-pass-unlock"
+                    type="password"
+                    autoComplete="current-password"
+                    placeholder="Unlock your saved key"
+                    value={passphraseUnlock}
+                    onChange={(e) => setPassphraseUnlock(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") void handleUnlock();
+                    }}
+                  />
+                </div>
+              ) : (
+                <>
+                  <p className="text-sm text-muted-foreground">
+                    Session is unlocked. Lock when you are done, or update the
+                    saved key below.
+                  </p>
+                  <div className="space-y-2 rounded-lg border bg-muted/30 p-3">
+                    <p className="text-xs font-medium text-foreground">
+                      Update saved key
+                    </p>
+                    <Input
+                      type="password"
+                      autoComplete="off"
+                      placeholder="New API key"
+                      value={apiKey}
+                      onChange={(e) => setApiKey(e.target.value)}
+                      className="h-9"
+                    />
+                    <Input
+                      type="password"
+                      autoComplete="new-password"
+                      placeholder="Passphrase"
+                      value={passphraseSave}
+                      onChange={(e) => setPassphraseSave(e.target.value)}
+                      className="h-9"
+                    />
+                  </div>
+                </>
+              )}
+            </div>
+          )}
+        </div>
+
+        <DialogFooter className="flex-col gap-3 border-t bg-muted/20 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex w-full flex-wrap gap-2 sm:w-auto">
+            {storedKeyPresent && sessionUnlocked && (
+              <>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={handleLockMemory}
+                >
+                  Lock session
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="text-destructive hover:text-destructive"
+                  onClick={handleRemoveStored}
+                >
+                  Remove saved key
+                </Button>
+              </>
+            )}
+          </div>
+          <div className="flex w-full justify-end gap-2 sm:w-auto">
+            {!storedKeyPresent ? (
+              <Button type="button" onClick={() => void handleSave()}>
+                Save & unlock
+              </Button>
+            ) : sessionUnlocked ? (
+              <Button
+                type="button"
+                disabled={!apiKey.trim() || !passphraseSave}
+                onClick={() => void handleSave()}
+              >
+                Update saved key
+              </Button>
+            ) : (
+              <Button type="button" onClick={() => void handleUnlock()}>
+                Unlock
+              </Button>
+            )}
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -17,6 +17,7 @@ import { AddRelationshipDialog } from "./AddRelationshipDialog";
 import { AddTableDialog } from "./AddTableDialog";
 import { AddZoneDialog } from "./AddZoneDialog";
 import { CheckpointMigrationDialog } from "./CheckpointMigrationDialog";
+import { AiChatFloating } from "./AiChatFloating";
 import DiagramEditor from "./DiagramEditor";
 import DiagramGallery from "./DiagramGallery";
 import { DiagramLayout } from "./DiagramLayout";
@@ -634,6 +635,7 @@ export default function Layout({ onInstallAppRequest }: LayoutProps) {
         <DiagramLayout
           sidebarContent={sidebarContent}
           diagramContent={<DiagramEditor setRfInstance={setRfInstance} />}
+          diagramOverlay={<AiChatFloating />}
           isSidebarOpen={isSidebarOpen}
           setIsSidebarOpen={setIsSidebarOpen}
           handleOpenSidebar={handleOpenSidebar}

--- a/src/components/TableNode.tsx
+++ b/src/components/TableNode.tsx
@@ -22,7 +22,7 @@ import {
   useUpdateNodeInternals,
   type NodeProps,
 } from "@xyflow/react";
-import { Copy, Key, MoreHorizontal, Trash2 } from "lucide-react";
+import { Copy, Key, MoreHorizontal, Sparkles, Trash2 } from "lucide-react";
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
 import { Button } from "./ui/button";
@@ -122,13 +122,15 @@ function TableNode({
   const prevColumnsRef = useRef(data.columns);
   const selectedNodeId = useStore((state) => state.selectedNodeId);
   const isSelected = selected || selectedNodeId === id;
-  const { selectedEdgeId, selectedDiagramId, diagramsMap } = useStore(
-    useShallow((state) => ({
-      selectedEdgeId: state.selectedEdgeId,
-      selectedDiagramId: state.selectedDiagramId,
-      diagramsMap: state.diagramsMap,
-    }))
-  );
+  const { selectedEdgeId, selectedDiagramId, diagramsMap, focusAiChatForTableNode } =
+    useStore(
+      useShallow((state) => ({
+        selectedEdgeId: state.selectedEdgeId,
+        selectedDiagramId: state.selectedDiagramId,
+        diagramsMap: state.diagramsMap,
+        focusAiChatForTableNode: state.focusAiChatForTableNode,
+      })),
+    );
   const edges = useMemo(
     () => (selectedDiagramId === null ? [] : diagramsMap.get(selectedDiagramId)?.data.edges || []),
     [selectedDiagramId, diagramsMap]
@@ -397,6 +399,9 @@ function TableNode({
       <ContextMenuContent>
         <ContextMenuItem onSelect={() => onCopy?.([id])}>
           <Copy className="h-4 w-4 mr-2" /> Copy Table
+        </ContextMenuItem>
+        <ContextMenuItem onSelect={() => focusAiChatForTableNode(id)}>
+          <Sparkles className="h-4 w-4 mr-2" /> Chat with AI
         </ContextMenuItem>
         <ContextMenuItem
           onSelect={() => onDelete?.([id])}

--- a/src/lib/ai/aiChatHistory.ts
+++ b/src/lib/ai/aiChatHistory.ts
@@ -1,0 +1,20 @@
+import { db } from "@/lib/db";
+import type { AiChatMessage } from "@/lib/types";
+
+export async function loadAiChatHistory(
+  diagramId: number,
+): Promise<AiChatMessage[]> {
+  const row = await db.aiChatSessions.get(diagramId);
+  return row?.messages ?? [];
+}
+
+export async function saveAiChatHistory(
+  diagramId: number,
+  messages: AiChatMessage[],
+): Promise<void> {
+  await db.aiChatSessions.put({
+    diagramId,
+    messages,
+    updatedAt: Date.now(),
+  });
+}

--- a/src/lib/ai/buildDiagramContext.ts
+++ b/src/lib/ai/buildDiagramContext.ts
@@ -1,0 +1,161 @@
+import type { Diagram } from "@/lib/types";
+
+export interface DiagramContextPayload {
+  dbType: Diagram["dbType"];
+  /** Table node id when a table is selected, else null. */
+  selectedNodeId: string | null;
+  /** Relationship edge id when selected, else null. */
+  selectedEdgeId: string | null;
+  /** Human-readable hint for what the user is focused on in the editor. */
+  editorFocus: string | null;
+  tables: {
+    id: string;
+    label: string;
+    comment?: string;
+    columns: {
+      id: string;
+      name: string;
+      type: string;
+      pk?: boolean;
+      nullable?: boolean;
+    }[];
+  }[];
+  relationships: {
+    id: string;
+    sourceTableId: string;
+    targetTableId: string;
+    sourceHandle: string;
+    targetHandle: string;
+    relationship: string;
+  }[];
+  /** Set when the user pins one or more tables from "Chat with AI". Null if not pinned. */
+  aiChatTarget: {
+    primaryTableIds: string[];
+    primaryLabels: string[];
+    /** Direct neighbors on the diagram of any primary, excluding primary ids. */
+    associatedTableIds: string[];
+    associatedTableLabels: string[];
+  } | null;
+}
+
+export function buildDiagramContext(
+  data: Diagram["data"],
+  dbType: Diagram["dbType"],
+  selectedNodeId: string | null,
+  selectedEdgeId: string | null,
+  /** Pinned tables from "Chat with AI" — adds scope + neighbor union to the payload. */
+  aiChatPinnedTableIds?: string[] | null,
+): DiagramContextPayload {
+  const tables = (data.nodes ?? [])
+    .filter((n) => n.type === "table" && !n.data.isDeleted)
+    .map((n) => ({
+      id: n.id,
+      label: n.data.label,
+      ...(n.data.comment ? { comment: n.data.comment } : {}),
+      columns: (n.data.columns ?? []).map((c) => ({
+        id: c.id,
+        name: c.name,
+        type: c.type,
+        ...(c.pk !== undefined ? { pk: c.pk } : {}),
+        ...(c.nullable !== undefined ? { nullable: c.nullable } : {}),
+      })),
+    }));
+
+  const relationships = (data.edges ?? []).map((e) => ({
+    id: e.id,
+    sourceTableId: e.source,
+    targetTableId: e.target,
+    sourceHandle: e.sourceHandle ?? "",
+    targetHandle: e.targetHandle ?? "",
+    relationship: e.data?.relationship ?? "one-to-many",
+  }));
+
+  const tableById = new Map(tables.map((t) => [t.id, t]));
+  const focusParts: string[] = [];
+
+  let aiChatTarget: DiagramContextPayload["aiChatTarget"] = null;
+  const rawPins = aiChatPinnedTableIds?.length ? aiChatPinnedTableIds : [];
+  const primaryTableIds: string[] = [];
+  const pinSeen = new Set<string>();
+  for (const id of rawPins) {
+    if (!tableById.has(id) || pinSeen.has(id)) continue;
+    pinSeen.add(id);
+    primaryTableIds.push(id);
+  }
+
+  if (primaryTableIds.length > 0) {
+    const primarySet = new Set(primaryTableIds);
+    const primaryLabels = primaryTableIds.map(
+      (id) => tableById.get(id)!.label,
+    );
+    const assocIds = new Set<string>();
+    for (const pid of primaryTableIds) {
+      for (const e of data.edges ?? []) {
+        if (e.source === pid) assocIds.add(e.target);
+        if (e.target === pid) assocIds.add(e.source);
+      }
+    }
+    const associatedTableIds = [...assocIds]
+      .filter((id) => !primarySet.has(id))
+      .sort();
+    const associatedTableLabels = associatedTableIds.map(
+      (id) => tableById.get(id)?.label ?? id,
+    );
+    aiChatTarget = {
+      primaryTableIds,
+      primaryLabels,
+      associatedTableIds,
+      associatedTableLabels,
+    };
+    const primaryPhrase = primaryLabels.map((l) => `"${l}"`).join(", ");
+    const assocPhrase =
+      associatedTableLabels.length > 0
+        ? associatedTableLabels.map((l) => `"${l}"`).join(", ")
+        : "none yet (no other tables linked on the diagram)";
+    focusParts.push(
+      `AI chat scope: primary tables ${primaryPhrase} (tableIds ${primaryTableIds.join(", ")}). Associated tables are direct neighbors not in the primary set—when the request affects FKs, types, names, or cardinality, keep this subgraph consistent: ${assocPhrase}.`,
+    );
+  }
+
+  if (selectedNodeId) {
+    const t = tableById.get(selectedNodeId);
+    if (t) {
+      focusParts.push(
+        `Selected table: "${t.label}" (use tableId "${selectedNodeId}" in operations).`,
+      );
+    } else {
+      focusParts.push(
+        `selectedNodeId is "${selectedNodeId}" (not a visible table id — user may have a note/zone selected or soft-deleted table).`,
+      );
+    }
+  }
+  if (selectedEdgeId) {
+    const r = relationships.find((x) => x.id === selectedEdgeId);
+    if (r) {
+      const from = tableById.get(r.sourceTableId)?.label ?? r.sourceTableId;
+      const to = tableById.get(r.targetTableId)?.label ?? r.targetTableId;
+      focusParts.push(
+        `Selected relationship: "${from}" → "${to}" (${r.relationship}), edgeId "${r.id}".`,
+      );
+    } else {
+      focusParts.push(
+        `selectedEdgeId "${selectedEdgeId}" not found on current diagram.`,
+      );
+    }
+  }
+  const editorFocus = focusParts.length > 0 ? focusParts.join(" ") : null;
+
+  return {
+    dbType,
+    selectedNodeId,
+    selectedEdgeId,
+    editorFocus,
+    tables,
+    relationships,
+    aiChatTarget,
+  };
+}
+
+export function diagramContextToPromptJson(ctx: DiagramContextPayload): string {
+  return JSON.stringify(ctx, null, 2);
+}

--- a/src/lib/ai/callGemini.ts
+++ b/src/lib/ai/callGemini.ts
@@ -1,0 +1,36 @@
+import { GoogleGenAI } from "@google/genai";
+
+/** Default model for diagram patches; override if a model id stops working. */
+export const GEMINI_DIAGRAM_MODEL = "gemini-2.5-flash";
+
+export async function callGeminiDiagramAssistant(params: {
+  apiKey: string;
+  systemInstruction: string;
+  history: { role: "user" | "model"; text: string }[];
+  userMessage: string;
+}): Promise<string> {
+  const ai = new GoogleGenAI({ apiKey: params.apiKey });
+  const contents = [
+    ...params.history.map((p) => ({
+      role: p.role,
+      parts: [{ text: p.text }],
+    })),
+    { role: "user" as const, parts: [{ text: params.userMessage }] },
+  ];
+
+  const response = await ai.models.generateContent({
+    model: GEMINI_DIAGRAM_MODEL,
+    contents,
+    config: {
+      systemInstruction: params.systemInstruction,
+      responseMimeType: "application/json",
+      temperature: 0.2,
+    },
+  });
+
+  const text = response.text;
+  if (!text?.trim()) {
+    throw new Error("Empty response from model.");
+  }
+  return text.trim();
+}

--- a/src/lib/ai/diagramPatchSchema.ts
+++ b/src/lib/ai/diagramPatchSchema.ts
@@ -1,0 +1,70 @@
+import { z } from "zod";
+
+const relationshipTypeEnum = z.enum([
+  "one-to-one",
+  "one-to-many",
+  "many-to-one",
+  "many-to-many",
+]);
+
+export const columnInputSchema = z.object({
+  id: z.string().optional(),
+  name: z.string().min(1),
+  type: z.string().min(1),
+  pk: z.boolean().optional(),
+  nullable: z.boolean().optional(),
+  defaultValue: z
+    .union([z.string(), z.number(), z.boolean(), z.null()])
+    .optional(),
+  isUnique: z.boolean().optional(),
+  isAutoIncrement: z.boolean().optional(),
+  comment: z.string().optional(),
+  enumValues: z.string().optional(),
+  length: z.number().optional(),
+  precision: z.number().optional(),
+  scale: z.number().optional(),
+  isUnsigned: z.boolean().optional(),
+});
+
+export const aiOperationSchema = z.discriminatedUnion("op", [
+  z.object({
+    op: z.literal("create_table"),
+    label: z.string().min(1),
+    columns: z.array(columnInputSchema).min(1),
+    position: z
+      .object({ x: z.number(), y: z.number() })
+      .optional(),
+  }),
+  z.object({
+    op: z.literal("update_table"),
+    tableId: z.string().min(1),
+    label: z.string().min(1).optional(),
+    columns: z.array(columnInputSchema).min(1).optional(),
+    comment: z.string().nullable().optional(),
+  }),
+  z.object({
+    op: z.literal("delete_table"),
+    tableId: z.string().min(1),
+  }),
+  z.object({
+    op: z.literal("create_relationship"),
+    sourceTableId: z.string().min(1),
+    sourceColumnId: z.string().min(1),
+    targetTableId: z.string().min(1),
+    targetColumnId: z.string().min(1),
+    relationshipType: relationshipTypeEnum,
+  }),
+  z.object({
+    op: z.literal("delete_relationship"),
+    edgeId: z.string().min(1),
+  }),
+]);
+
+export const aiPatchSchema = z.object({
+  summary: z.string().optional(),
+  operations: z.array(aiOperationSchema),
+});
+
+export type AiPatch = z.infer<typeof aiPatchSchema>;
+export type AiOperation = z.infer<typeof aiOperationSchema>;
+export type ColumnInput = z.infer<typeof columnInputSchema>;

--- a/src/lib/ai/geminiEncryptedStorage.ts
+++ b/src/lib/ai/geminiEncryptedStorage.ts
@@ -1,0 +1,144 @@
+const STORAGE_KEY = "thoth.gemini.enc";
+/** Plaintext key for current browser tab only; cleared when the tab closes or user locks. */
+const SESSION_KEY = "thoth.gemini.session";
+const VERSION = 1;
+const PBKDF2_ITERATIONS = 210_000;
+
+export interface EncryptedKeyBlob {
+  v: number;
+  salt: string;
+  iv: string;
+  ciphertext: string;
+}
+
+function toB64(buf: ArrayBuffer | Uint8Array): string {
+  const u8 = buf instanceof Uint8Array ? buf : new Uint8Array(buf);
+  let s = "";
+  for (let i = 0; i < u8.length; i++) s += String.fromCharCode(u8[i]!);
+  return btoa(s);
+}
+
+function fromB64(b64: string): Uint8Array {
+  const bin = atob(b64);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+async function deriveAesKey(
+  passphrase: string,
+  salt: Uint8Array,
+): Promise<CryptoKey> {
+  const saltBuf = new Uint8Array(salt);
+  const enc = new TextEncoder();
+  const passphraseBytes = new Uint8Array(enc.encode(passphrase));
+  const keyMaterial = await crypto.subtle.importKey(
+    "raw",
+    passphraseBytes,
+    "PBKDF2",
+    false,
+    ["deriveKey"],
+  );
+  return crypto.subtle.deriveKey(
+    {
+      name: "PBKDF2",
+      salt: saltBuf,
+      iterations: PBKDF2_ITERATIONS,
+      hash: "SHA-256",
+    },
+    keyMaterial,
+    { name: "AES-GCM", length: 256 },
+    false,
+    ["encrypt", "decrypt"],
+  );
+}
+
+export function hasEncryptedGeminiKey(): boolean {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return false;
+    const parsed = JSON.parse(raw) as EncryptedKeyBlob;
+    return (
+      parsed.v === VERSION &&
+      typeof parsed.salt === "string" &&
+      typeof parsed.iv === "string" &&
+      typeof parsed.ciphertext === "string"
+    );
+  } catch {
+    return false;
+  }
+}
+
+export async function saveEncryptedGeminiKey(
+  apiKey: string,
+  passphrase: string,
+): Promise<void> {
+  const salt = crypto.getRandomValues(new Uint8Array(16));
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const aesKey = await deriveAesKey(passphrase, salt);
+  const enc = new TextEncoder();
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv },
+    aesKey,
+    enc.encode(apiKey),
+  );
+  const blob: EncryptedKeyBlob = {
+    v: VERSION,
+    salt: toB64(salt),
+    iv: toB64(iv),
+    ciphertext: toB64(ciphertext),
+  };
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(blob));
+}
+
+export async function decryptGeminiKey(passphrase: string): Promise<string> {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (!raw) throw new Error("No saved API key.");
+  const blob = JSON.parse(raw) as EncryptedKeyBlob;
+  if (blob.v !== VERSION) throw new Error("Unsupported key format.");
+  const salt = new Uint8Array(fromB64(blob.salt));
+  const iv = new Uint8Array(fromB64(blob.iv));
+  const data = new Uint8Array(fromB64(blob.ciphertext));
+  const aesKey = await deriveAesKey(passphrase, salt);
+  let plain: ArrayBuffer;
+  try {
+    plain = await crypto.subtle.decrypt(
+      { name: "AES-GCM", iv },
+      aesKey,
+      data,
+    );
+  } catch {
+    throw new Error("Wrong passphrase or corrupted data.");
+  }
+  return new TextDecoder().decode(plain);
+}
+
+export function clearEncryptedGeminiKey(): void {
+  localStorage.removeItem(STORAGE_KEY);
+  clearGeminiKeySession();
+}
+
+/** Remember decrypted key until tab close or explicit lock (not persisted across tabs). */
+export function saveGeminiKeyToSession(apiKey: string): void {
+  try {
+    sessionStorage.setItem(SESSION_KEY, apiKey);
+  } catch {
+    // private mode / quota
+  }
+}
+
+export function loadGeminiKeyFromSession(): string | null {
+  try {
+    return sessionStorage.getItem(SESSION_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function clearGeminiKeySession(): void {
+  try {
+    sessionStorage.removeItem(SESSION_KEY);
+  } catch {
+    // ignore
+  }
+}

--- a/src/lib/ai/parseSqlColumnType.ts
+++ b/src/lib/ai/parseSqlColumnType.ts
@@ -1,0 +1,100 @@
+import { dataTypes } from "@/lib/db-types";
+import type { DatabaseType } from "@/lib/types";
+
+export interface ParsedSqlColumnType {
+  baseName: string;
+  length?: number;
+  precision?: number;
+  scale?: number;
+  isUnsigned?: boolean;
+}
+
+/**
+ * Parses common SQL-style declarations (e.g. VARCHAR(50), DECIMAL(10,2), INT UNSIGNED)
+ * so they can be matched against ThothBlueprint's allowed type tokens.
+ */
+export function parseSqlColumnType(raw: string): ParsedSqlColumnType {
+  let s = raw.trim().replace(/\s+/g, " ");
+  const isUnsigned = /\bUNSIGNED\b/i.test(s);
+  s = s
+    .replace(/\bUNSIGNED\b/gi, "")
+    .replace(/\bZEROFILL\b/gi, "")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  const parenOpen = s.indexOf("(");
+  let baseName: string;
+  let inner = "";
+
+  if (parenOpen < 0) {
+    baseName = s;
+  } else {
+    baseName = s.slice(0, parenOpen).trim();
+    const parenClose = s.lastIndexOf(")");
+    inner =
+      parenClose > parenOpen ? s.slice(parenOpen + 1, parenClose).trim() : "";
+  }
+
+  const result: ParsedSqlColumnType = {
+    baseName,
+    ...(isUnsigned ? { isUnsigned: true } : {}),
+  };
+
+  if (!inner) return result;
+
+  if (/^['"]/u.test(inner) || inner.includes("'") || inner.includes('"')) {
+    return result;
+  }
+
+  const parts = inner.split(",").map((p) => p.trim());
+  const n0 = parts[0] !== undefined ? parseInt(parts[0], 10) : NaN;
+  const n1 = parts[1] !== undefined ? parseInt(parts[1], 10) : NaN;
+
+  if (parts.length >= 2 && !Number.isNaN(n0) && !Number.isNaN(n1)) {
+    result.precision = n0;
+    result.scale = n1;
+    return result;
+  }
+
+  if (parts.length >= 1 && !Number.isNaN(n0)) {
+    const u = baseName.toUpperCase();
+    if (
+      u === "DECIMAL" ||
+      u === "NUMERIC" ||
+      u === "DEC" ||
+      u === "FIXED"
+    ) {
+      result.precision = n0;
+    } else if (
+      u === "TIMESTAMP" ||
+      u === "TIME" ||
+      u === "DATETIME" ||
+      u === "TIMESTAMPTZ" ||
+      u === "TIMETZ"
+    ) {
+      result.precision = n0;
+    } else {
+      result.length = n0;
+    }
+  }
+
+  return result;
+}
+
+export function resolveCanonicalColumnType(
+  dbType: DatabaseType,
+  rawType: string,
+):
+  | { ok: true; canonical: string; parsed: ParsedSqlColumnType }
+  | { ok: false } {
+  const parsed = parseSqlColumnType(rawType);
+  const allowed = dataTypes[dbType];
+  if (!allowed?.length) return { ok: false };
+
+  const found = allowed.find(
+    (x) => x.toLowerCase() === parsed.baseName.toLowerCase(),
+  );
+  if (!found) return { ok: false };
+
+  return { ok: true, canonical: found, parsed };
+}

--- a/src/lib/ai/simulateAiPatch.ts
+++ b/src/lib/ai/simulateAiPatch.ts
@@ -1,0 +1,400 @@
+import { colors } from "@/lib/constants";
+import { tableColors } from "@/lib/colors";
+import type {
+  AppEdge,
+  AppNode,
+  Column,
+  CombinedNode,
+  DatabaseType,
+  Diagram,
+  Index,
+} from "@/lib/types";
+import {
+  DEFAULT_NODE_SPACING,
+  DEFAULT_TABLE_HEIGHT,
+  DEFAULT_TABLE_WIDTH,
+  findExistingRelationship,
+  findNonOverlappingPosition,
+  uuid,
+} from "@/lib/utils";
+import type { AiOperation, ColumnInput } from "./diagramPatchSchema";
+import { resolveCanonicalColumnType } from "./parseSqlColumnType";
+
+export type SimulateAiResult =
+  | { ok: true; data: Diagram["data"] }
+  | { ok: false; error: string };
+
+function cloneData(data: Diagram["data"]): Diagram["data"] {
+  return JSON.parse(JSON.stringify(data)) as Diagram["data"];
+}
+
+function visibleTables(nodes: AppNode[] | undefined): AppNode[] {
+  return (nodes ?? []).filter((n) => n.type === "table" && !n.data.isDeleted);
+}
+
+function tableColumns(node: AppNode): Column[] {
+  return node.data.columns ?? [];
+}
+
+/** Normalize for case-insensitive label/name matching (AI often sends labels vs ids). */
+function normalizeRef(s: string): string {
+  return s.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+/** Resolve a table by exact node id or by table label (visible, non-deleted). */
+function resolveTableNode(
+  draft: Diagram["data"],
+  ref: string,
+): AppNode | undefined {
+  const r = ref.trim();
+  if (!r) return undefined;
+  const visible = visibleTables((draft.nodes ?? []) as AppNode[]);
+  const byId = visible.find((n) => n.id === r);
+  if (byId) return byId;
+  const key = normalizeRef(r);
+  return visible.find((n) => normalizeRef(n.data.label) === key);
+}
+
+/** Resolve a column by id or by column name on the given table. */
+function resolveColumnRef(node: AppNode, ref: string): Column | undefined {
+  const r = ref.trim();
+  if (!r) return undefined;
+  const cols = tableColumns(node);
+  const byId = cols.find((c) => c.id === r);
+  if (byId) return byId;
+  const key = normalizeRef(r);
+  return cols.find((c) => normalizeRef(c.name) === key);
+}
+
+function labelTaken(
+  nodes: AppNode[] | undefined,
+  label: string,
+  exceptId?: string,
+): boolean {
+  const ln = label.trim().toLowerCase();
+  return visibleTables(nodes).some(
+    (n) =>
+      n.id !== exceptId && n.data.label.trim().toLowerCase() === ln,
+  );
+}
+
+function filterIndicesForColumns(
+  indices: Index[] | undefined,
+  columns: Column[],
+): Index[] | undefined {
+  if (!indices?.length) return indices;
+  const names = new Set(columns.map((c) => c.name));
+  const next = indices.filter((idx) =>
+    idx.columns.every((cn) => names.has(cn)),
+  );
+  return next.length ? next : undefined;
+}
+
+function columnFromInput(
+  inp: ColumnInput,
+  dbType: DatabaseType,
+  existing: Column | undefined,
+  opts: { allowAdhocId: boolean },
+): { ok: true; column: Column } | { ok: false; error: string } {
+  const resolved = resolveCanonicalColumnType(dbType, inp.type);
+  if (!resolved.ok) {
+    return {
+      ok: false,
+      error: `Invalid column type "${inp.type}" for ${dbType}.`,
+    };
+  }
+  const normType = resolved.canonical;
+  const parsed = resolved.parsed;
+  if (inp.id && !existing && !opts.allowAdhocId) {
+    return { ok: false, error: `Unknown column id "${inp.id}".` };
+  }
+  const id =
+    existing?.id ??
+    (inp.id && opts.allowAdhocId ? inp.id : undefined) ??
+    `col_${uuid()}`;
+
+  const col: Column = {
+    ...(existing ?? { id, name: inp.name, type: normType }),
+    id,
+    name: inp.name,
+    type: normType,
+    pk: inp.pk ?? existing?.pk ?? false,
+    nullable:
+      inp.nullable !== undefined
+        ? inp.nullable
+        : (existing?.nullable ?? true),
+  };
+  if (inp.defaultValue !== undefined) col.defaultValue = inp.defaultValue;
+  if (inp.isUnique !== undefined) col.isUnique = inp.isUnique;
+  if (inp.isAutoIncrement !== undefined)
+    col.isAutoIncrement = inp.isAutoIncrement;
+  if (inp.comment !== undefined) col.comment = inp.comment;
+  if (inp.enumValues !== undefined) col.enumValues = inp.enumValues;
+  if (inp.length !== undefined) col.length = inp.length;
+  else if (parsed.length !== undefined) col.length = parsed.length;
+  if (inp.precision !== undefined) col.precision = inp.precision;
+  else if (parsed.precision !== undefined) col.precision = parsed.precision;
+  if (inp.scale !== undefined) col.scale = inp.scale;
+  else if (parsed.scale !== undefined) col.scale = parsed.scale;
+  if (inp.isUnsigned !== undefined) col.isUnsigned = inp.isUnsigned;
+  else if (parsed.isUnsigned) col.isUnsigned = true;
+
+  return { ok: true, column: col };
+}
+
+function combinedNodesForLayout(draft: Diagram["data"]): CombinedNode[] {
+  return [
+    ...((draft.nodes ?? []) as CombinedNode[]),
+    ...((draft.notes ?? []) as CombinedNode[]),
+    ...((draft.zones ?? []) as CombinedNode[]),
+  ];
+}
+
+function applyOneOp(
+  draft: Diagram["data"],
+  dbType: DatabaseType,
+  op: AiOperation,
+): SimulateAiResult {
+  if (op.op === "create_table") {
+    const nodes = (draft.nodes ?? []) as AppNode[];
+    if (labelTaken(nodes, op.label)) {
+      return {
+        ok: false,
+        error: `Table label "${op.label}" already exists.`,
+      };
+    }
+    const cols: Column[] = [];
+    const seenIds = new Set<string>();
+    for (const inp of op.columns) {
+      const r = columnFromInput(inp, dbType, undefined, { allowAdhocId: true });
+      if (!r.ok) return r;
+      if (seenIds.has(r.column.id)) {
+        return { ok: false, error: `Duplicate column id ${r.column.id}.` };
+      }
+      seenIds.add(r.column.id);
+      cols.push(r.column);
+    }
+    const visible = visibleTables(nodes);
+    const tableLabelSafe = op.label.replace(/\s+/g, "_");
+    const newId = `${tableLabelSafe}-${Date.now()}`;
+    const defaultPos = op.position ?? {
+      x: 200 + visible.length * 24,
+      y: 200 + visible.length * 24,
+    };
+    const position = findNonOverlappingPosition(
+      combinedNodesForLayout(draft),
+      defaultPos,
+      DEFAULT_TABLE_WIDTH,
+      DEFAULT_TABLE_HEIGHT,
+      DEFAULT_NODE_SPACING,
+      undefined,
+    );
+    const newNode: AppNode = {
+      id: newId,
+      type: "table",
+      position,
+      data: {
+        label: op.label.trim(),
+        color:
+          tableColors[Math.floor(Math.random() * tableColors.length)] ??
+          colors.DEFAULT_TABLE_COLOR,
+        columns: cols,
+        order: visible.length,
+      },
+    };
+    return {
+      ok: true,
+      data: {
+        ...draft,
+        nodes: [...nodes, newNode],
+      },
+    };
+  }
+
+  if (op.op === "update_table") {
+    const nodes = [...((draft.nodes ?? []) as AppNode[])];
+    const resolved = resolveTableNode(draft, op.tableId);
+    if (!resolved) {
+      return { ok: false, error: `Unknown table "${op.tableId}".` };
+    }
+    const idx = nodes.findIndex(
+      (n) =>
+        n.id === resolved.id && n.type === "table" && !n.data.isDeleted,
+    );
+    if (idx === -1) {
+      return { ok: false, error: `Unknown table "${op.tableId}".` };
+    }
+    const node = nodes[idx]!;
+    let label = node.data.label;
+    if (op.label !== undefined) {
+      const nl = op.label.trim();
+      if (labelTaken(nodes, nl, node.id)) {
+        return { ok: false, error: `Table label "${nl}" already exists.` };
+      }
+      label = nl;
+    }
+    let columns = node.data.columns ?? [];
+    if (op.columns) {
+      const existingById = new Map(columns.map((c) => [c.id, c]));
+      const nextCols: Column[] = [];
+      const seen = new Set<string>();
+      for (const inp of op.columns) {
+        const existing =
+          inp.id !== undefined ? existingById.get(inp.id) : undefined;
+        const allowAdhocId = inp.id !== undefined && !existing;
+        const r = columnFromInput(inp, dbType, existing, {
+          allowAdhocId,
+        });
+        if (!r.ok) return r;
+        if (seen.has(r.column.id)) {
+          return { ok: false, error: `Duplicate column id ${r.column.id}.` };
+        }
+        seen.add(r.column.id);
+        nextCols.push(r.column);
+      }
+      if (nextCols.length === 0) {
+        return { ok: false, error: "Table must have at least one column." };
+      }
+      columns = nextCols;
+    }
+    const {
+      indices: prevIndices,
+      comment: prevComment,
+      ...dataRest
+    } = node.data;
+    let nextComment: string | undefined = prevComment;
+    if (op.comment !== undefined) {
+      nextComment = op.comment ?? undefined;
+    }
+    let nextIndices: Index[] | undefined = prevIndices;
+    if (op.columns) {
+      const fi = filterIndicesForColumns(prevIndices, columns);
+      nextIndices = fi && fi.length > 0 ? fi : undefined;
+    }
+    const updated: AppNode = {
+      ...node,
+      data: {
+        ...dataRest,
+        label,
+        columns,
+        ...(nextComment !== undefined ? { comment: nextComment } : {}),
+        ...(nextIndices?.length ? { indices: nextIndices } : {}),
+      },
+    };
+    nodes[idx] = updated;
+    return { ok: true, data: { ...draft, nodes } };
+  }
+
+  if (op.op === "delete_table") {
+    const nodes = [...((draft.nodes ?? []) as AppNode[])];
+    const resolved = resolveTableNode(draft, op.tableId);
+    if (!resolved) {
+      return { ok: false, error: `Unknown table "${op.tableId}".` };
+    }
+    const idx = nodes.findIndex(
+      (n) =>
+        n.id === resolved.id && n.type === "table" && !n.data.isDeleted,
+    );
+    if (idx === -1) {
+      return { ok: false, error: `Unknown table "${op.tableId}".` };
+    }
+    const n = nodes[idx]!;
+    nodes[idx] = {
+      ...n,
+      data: {
+        ...n.data,
+        isDeleted: true,
+        deletedAt: new Date(),
+      },
+    };
+    const edges = (draft.edges ?? []).filter(
+      (e) => e.source !== n.id && e.target !== n.id,
+    );
+    return { ok: true, data: { ...draft, nodes, edges } };
+  }
+
+  if (op.op === "create_relationship") {
+    const sourceNode = resolveTableNode(draft, op.sourceTableId);
+    const targetNode = resolveTableNode(draft, op.targetTableId);
+    if (!sourceNode || !targetNode) {
+      return {
+        ok: false,
+        error:
+          'Source or target table not found. Use tables[].id from the diagram or the table\'s "label" (e.g. after create_table in the same batch).',
+      };
+    }
+    const sc = resolveColumnRef(sourceNode, op.sourceColumnId);
+    const tc = resolveColumnRef(targetNode, op.targetColumnId);
+    if (!sc || !tc) {
+      return {
+        ok: false,
+        error:
+          "Source or target column not found. Use columns[].id or the column name string.",
+      };
+    }
+    if (sc.type !== tc.type) {
+      return {
+        ok: false,
+        error: "Column types must match for a relationship.",
+      };
+    }
+    const sourceHandle = `${sc.id}-right-source`;
+    const targetHandle = `${tc.id}-left-target`;
+    const edges = draft.edges ?? [];
+    const existingEdge = findExistingRelationship(
+      edges as AppEdge[],
+      sourceNode.id,
+      targetNode.id,
+      sourceHandle,
+      targetHandle,
+    );
+    if (existingEdge) {
+      return { ok: false, error: "This relationship already exists." };
+    }
+    const newEdge: AppEdge = {
+      id: `${sourceNode.id}-${targetNode.id}-${sourceHandle}-${targetHandle}`,
+      source: sourceNode.id,
+      target: targetNode.id,
+      sourceHandle,
+      targetHandle,
+      type: "custom",
+      data: { relationship: op.relationshipType },
+    };
+    return {
+      ok: true,
+      data: { ...draft, edges: [...edges, newEdge] },
+    };
+  }
+
+  if (op.op === "delete_relationship") {
+    const edges = draft.edges ?? [];
+    if (!edges.some((e) => e.id === op.edgeId)) {
+      return { ok: false, error: `Unknown relationship "${op.edgeId}".` };
+    }
+    return {
+      ok: true,
+      data: {
+        ...draft,
+        edges: edges.filter((e) => e.id !== op.edgeId),
+      },
+    };
+  }
+
+  return { ok: false, error: "Unsupported operation." };
+}
+
+export function simulateAiPatch(
+  data: Diagram["data"],
+  dbType: DatabaseType,
+  operations: AiOperation[],
+): SimulateAiResult {
+  let draft = cloneData(data);
+
+  for (const op of operations) {
+    const res = applyOneOp(draft, dbType, op);
+    if (!res.ok) return res;
+    draft = res.data;
+  }
+
+  return { ok: true, data: draft };
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,10 +1,16 @@
 import Dexie, { type Table } from "dexie";
-import { AppState, Diagram, DiagramCheckpoint } from "./types";
+import {
+  type AiChatSession,
+  AppState,
+  Diagram,
+  DiagramCheckpoint,
+} from "./types";
 
 export class Database extends Dexie {
   diagrams!: Table<Diagram>;
   appState!: Table<AppState>;
   checkpoints!: Table<DiagramCheckpoint>;
+  aiChatSessions!: Table<AiChatSession>;
 
   constructor() {
     super("ThothBlueprintDB");
@@ -79,6 +85,12 @@ export class Database extends Dexie {
       diagrams: "++id, name, dbType, createdAt, updatedAt, deletedAt",
       appState: "key",
       checkpoints: "++id, diagramId, checkpointNumber, createdAt, type",
+    });
+    this.version(9).stores({
+      diagrams: "++id, name, dbType, createdAt, updatedAt, deletedAt",
+      appState: "key",
+      checkpoints: "++id, diagramId, checkpointNumber, createdAt, type",
+      aiChatSessions: "diagramId",
     });
   }
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -42,6 +42,14 @@ export interface AppState {
   value: string | number;
 }
 
+export type AiChatMessage = { role: "user" | "model"; content: string };
+
+export interface AiChatSession {
+  diagramId: number;
+  messages: AiChatMessage[];
+  updatedAt: number;
+}
+
 export type CheckpointType = "automatic" | "manual" | "migration";
 
 export interface DiagramCheckpoint {

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -17,6 +17,8 @@ import {
   type Diagram,
   type DiagramCheckpoint,
 } from "@/lib/types";
+import { aiPatchSchema } from "@/lib/ai/diagramPatchSchema";
+import { simulateAiPatch } from "@/lib/ai/simulateAiPatch";
 import { findExistingRelationship } from "@/lib/utils";
 import {
   applyEdgeChanges,
@@ -35,6 +37,19 @@ export interface StoreState {
   selectedDiagramId: number | null;
   selectedNodeId: string | null;
   selectedEdgeId: string | null;
+  /** Bumped to switch the editor sidebar tab (does not open or expand the sidebar). */
+  editorSidebarNavigateToken: number;
+  /** Sidebar tab to show when `editorSidebarNavigateToken` changes; cleared after consumption. */
+  editorSidebarNavigateTargetTab:
+    | "tables"
+    | "relationships"
+    | "dbml"
+    | "ai"
+    | null;
+  /** Table node ids pinned from "Chat with AI" (additive); drives scope chips and diagram JSON. */
+  aiChatPinnedTableIds: string[];
+  /** Incremented when opening AI from a table context menu so the sidebar stays on the AI tab. */
+  aiChatTabSyncSuppressToken: number;
   settings: Settings;
   isLoading: boolean;
   clipboard: (AppNode | AppNoteNode | AppZoneNode)[] | null;
@@ -45,6 +60,11 @@ export interface StoreState {
   setSelectedDiagramId: (id: number | null) => void;
   setSelectedNodeId: (id: string | null) => void;
   setSelectedEdgeId: (id: string | null) => void;
+  focusAiChatForTableNode: (tableId: string) => void;
+  clearEditorSidebarNavigateTarget: () => void;
+  clearAiChatPinnedTables: () => void;
+  removeAiChatPinnedTable: (tableId: string) => void;
+  setAiChatPinnedTableIds: (ids: string[]) => void;
   setLastCursorPosition: (position: { x: number; y: number } | null) => void;
   updateSettings: (settings: Partial<Settings>) => void;
   createDiagram: (
@@ -69,6 +89,11 @@ export interface StoreState {
   updateEdge: (edge: AppEdge) => void;
   deleteEdge: (edgeId: string) => void;
   addNode: (node: AppNode | AppNoteNode | AppZoneNode) => void;
+  applyAiDiagramOperations: (
+    raw: unknown,
+  ) =>
+    | { ok: true; summary?: string }
+    | { ok: false; error: string };
   undoDelete: () => void;
   batchUpdateNodes: (nodes: (AppNode | AppNoteNode | AppZoneNode)[]) => void;
   copyNodes: (nodes: (AppNode | AppNoteNode | AppZoneNode)[]) => void;
@@ -233,7 +258,12 @@ const debouncedSavePositions = debounce(
 const debouncedSaveFull = debounce(
   async (diagrams: Diagram[], selectedDiagramId: number | null) => {
     try {
-      await db.transaction("rw", db.diagrams, db.appState, async () => {
+      await db.transaction(
+        "rw",
+        db.diagrams,
+        db.appState,
+        db.aiChatSessions,
+        async () => {
         const allDbDiagramIds = (await db.diagrams
           .toCollection()
           .primaryKeys()) as number[];
@@ -249,6 +279,7 @@ const debouncedSaveFull = debounce(
           );
           if (idsToDelete.length > 0) {
             await db.diagrams.bulkDelete(idsToDelete);
+            await db.aiChatSessions.bulkDelete(idsToDelete);
           }
         }
 
@@ -264,7 +295,8 @@ const debouncedSaveFull = debounce(
         } else {
           await db.appState.delete("selectedDiagramId").catch(() => {});
         }
-      });
+        },
+      );
 
       previousDiagrams = diagrams;
       previousSelectedDiagramId = selectedDiagramId;
@@ -675,6 +707,10 @@ export const useStore = create<StoreState>()(
     selectedDiagramId: null,
     selectedNodeId: null,
     selectedEdgeId: null,
+    editorSidebarNavigateToken: 0,
+    editorSidebarNavigateTargetTab: null,
+    aiChatPinnedTableIds: [],
+    aiChatTabSyncSuppressToken: 0,
     settings: DEFAULT_SETTINGS,
     isLoading: true,
     clipboard: null,
@@ -732,9 +768,32 @@ export const useStore = create<StoreState>()(
         selectedDiagramId: id,
         selectedNodeId: null,
         selectedEdgeId: null,
+        aiChatPinnedTableIds: [],
       }),
     setSelectedNodeId: (id) => set({ selectedNodeId: id }),
     setSelectedEdgeId: (id) => set({ selectedEdgeId: id }),
+    focusAiChatForTableNode: (tableId) =>
+      set((s) => {
+        const ids = s.aiChatPinnedTableIds.includes(tableId)
+          ? s.aiChatPinnedTableIds
+          : [...s.aiChatPinnedTableIds, tableId];
+        return {
+          selectedNodeId: tableId,
+          selectedEdgeId: null,
+          aiChatPinnedTableIds: ids,
+          aiChatTabSyncSuppressToken: s.aiChatTabSyncSuppressToken + 1,
+          editorSidebarNavigateToken: s.editorSidebarNavigateToken + 1,
+          editorSidebarNavigateTargetTab: "ai",
+        };
+      }),
+    clearEditorSidebarNavigateTarget: () =>
+      set({ editorSidebarNavigateTargetTab: null }),
+    clearAiChatPinnedTables: () => set({ aiChatPinnedTableIds: [] }),
+    removeAiChatPinnedTable: (tableId) =>
+      set((s) => ({
+        aiChatPinnedTableIds: s.aiChatPinnedTableIds.filter((id) => id !== tableId),
+      })),
+    setAiChatPinnedTableIds: (ids) => set({ aiChatPinnedTableIds: ids }),
     setLastCursorPosition: (position) => set({ lastCursorPosition: position }),
     updateSettings: (newSettings) => {
       set((state) => {
@@ -1248,6 +1307,59 @@ export const useStore = create<StoreState>()(
           ),
         );
       });
+    },
+    applyAiDiagramOperations: (raw) => {
+      const state = get();
+      const diagram = getDiagramById(
+        state.diagramsMap,
+        state.selectedDiagramId,
+      );
+      if (!diagram?.id) {
+        return { ok: false, error: "No diagram selected." };
+      }
+      if (diagram.data.isLocked) {
+        return { ok: false, error: "Diagram is locked." };
+      }
+
+      const parsed = aiPatchSchema.safeParse(raw);
+      if (!parsed.success) {
+        const msg = parsed.error.issues.map((i) => i.message).join("; ");
+        return { ok: false, error: msg || "Invalid AI response format." };
+      }
+
+      try {
+        const { operations, summary } = parsed.data;
+        if (operations.length === 0) {
+          return summary !== undefined
+            ? { ok: true, summary }
+            : { ok: true };
+        }
+
+        const sim = simulateAiPatch(diagram.data, diagram.dbType, operations);
+        if (!sim.ok) {
+          return { ok: false, error: sim.error };
+        }
+
+        set((s) =>
+          updateDiagramsWithMap(s.diagrams, (diagrams) =>
+            diagrams.map((d) =>
+              d.id === s.selectedDiagramId
+                ? {
+                    ...d,
+                    data: sim.data,
+                    updatedAt: new Date(),
+                  }
+                : d,
+            ),
+          ),
+        );
+
+        return summary !== undefined ? { ok: true, summary } : { ok: true };
+      } catch (e) {
+        console.error("applyAiDiagramOperations:", e);
+        const msg = e instanceof Error ? e.message : String(e);
+        return { ok: false, error: msg };
+      }
     },
     undoDelete: () => {
       set((state) => {

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -44,12 +44,11 @@ export interface StoreState {
     | "tables"
     | "relationships"
     | "dbml"
-    | "ai"
     | null;
   /** Table node ids pinned from "Chat with AI" (additive); drives scope chips and diagram JSON. */
   aiChatPinnedTableIds: string[];
-  /** Incremented when opening AI from a table context menu so the sidebar stays on the AI tab. */
-  aiChatTabSyncSuppressToken: number;
+  /** Floating schema assistant panel over the diagram canvas. */
+  aiChatPanelOpen: boolean;
   settings: Settings;
   isLoading: boolean;
   clipboard: (AppNode | AppNoteNode | AppZoneNode)[] | null;
@@ -61,6 +60,7 @@ export interface StoreState {
   setSelectedNodeId: (id: string | null) => void;
   setSelectedEdgeId: (id: string | null) => void;
   focusAiChatForTableNode: (tableId: string) => void;
+  setAiChatPanelOpen: (open: boolean) => void;
   clearEditorSidebarNavigateTarget: () => void;
   clearAiChatPinnedTables: () => void;
   removeAiChatPinnedTable: (tableId: string) => void;
@@ -710,7 +710,7 @@ export const useStore = create<StoreState>()(
     editorSidebarNavigateToken: 0,
     editorSidebarNavigateTargetTab: null,
     aiChatPinnedTableIds: [],
-    aiChatTabSyncSuppressToken: 0,
+    aiChatPanelOpen: false,
     settings: DEFAULT_SETTINGS,
     isLoading: true,
     clipboard: null,
@@ -769,6 +769,7 @@ export const useStore = create<StoreState>()(
         selectedNodeId: null,
         selectedEdgeId: null,
         aiChatPinnedTableIds: [],
+        aiChatPanelOpen: false,
       }),
     setSelectedNodeId: (id) => set({ selectedNodeId: id }),
     setSelectedEdgeId: (id) => set({ selectedEdgeId: id }),
@@ -781,11 +782,10 @@ export const useStore = create<StoreState>()(
           selectedNodeId: tableId,
           selectedEdgeId: null,
           aiChatPinnedTableIds: ids,
-          aiChatTabSyncSuppressToken: s.aiChatTabSyncSuppressToken + 1,
-          editorSidebarNavigateToken: s.editorSidebarNavigateToken + 1,
-          editorSidebarNavigateTargetTab: "ai",
+          aiChatPanelOpen: true,
         };
       }),
+    setAiChatPanelOpen: (open) => set({ aiChatPanelOpen: open }),
     clearEditorSidebarNavigateTarget: () =>
       set({ editorSidebarNavigateTargetTab: null }),
     clearAiChatPinnedTables: () => set({ aiChatPinnedTableIds: [] }),

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -85,10 +85,20 @@ export default {
             height: "0",
           },
         },
+        "ai-chat-shimmer": {
+          "0%": { backgroundPosition: "200% center" },
+          "100%": { backgroundPosition: "-200% center" },
+        },
+        "ai-thinking-dot": {
+          "0%, 100%": { opacity: "0.35", transform: "translateY(0)" },
+          "50%": { opacity: "1", transform: "translateY(-3px)" },
+        },
       },
       animation: {
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
+        "ai-chat-shimmer": "ai-chat-shimmer 3s ease-in-out infinite",
+        "ai-thinking-dot": "ai-thinking-dot 0.9s ease-in-out infinite",
       },
     },
   },


### PR DESCRIPTION
## Description
This PR delivers in-app AI assistance for schema work by adding a schema assistant (AI chat bot) on the diagram editor.

The assistant lives in a floating panel over the canvas (sparkles FAB), so it stays available without crowding the sidebar. Users can chat in natural language to get suggestions; the app sends diagram context with each turn and can apply validated diagram operations when the model returns supported JSON patches.

**Highlights**

- Floating chat UI with open/close, mobile-friendly backdrop, and keyboard support (Escape when no modal is open).

- Table context menu can focus the assistant and pin tables for scoped prompts.
- API key flow unchanged in spirit: unlock Gemini in-session; compact header with privacy / accuracy / local history details in the help popover.
- Chat history persisted locally per diagram (this device / browser only—not synced).

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [ ] Tests added/updated
- [x] All tests pass locally
- [ ] Tested on multiple browsers (Chrome, Firefox, Safari, Edge)

**Test Environment:**
- Browser: Chrome
- OS: MacOS

## Checklist

- [x] Code follows project style
- [x] Self-reviewed code
- [ ] Updated documentation
- [ ] Backward compatible (or breaking change documented)
- [x] No new warnings/errors

## Additional Notes

<img width="1728" height="995" alt="image" src="https://github.com/user-attachments/assets/81f4b626-6989-4ac4-aa33-3e3aa5148d25" />
<img width="494" height="881" alt="image" src="https://github.com/user-attachments/assets/4ded04c4-f3fd-4a29-972e-7812d6a5d909" />
<img width="1299" height="835" alt="image" src="https://github.com/user-attachments/assets/50cbe3fe-144a-4606-83aa-82c5e53e42e6" />
<img width="1728" height="997" alt="image" src="https://github.com/user-attachments/assets/08109ec1-6e3c-4b36-ad48-e8a2f3d06192" />
